### PR TITLE
Fix CustomFieldChoices Import

### DIFF
--- a/nautobot_netbox_importer/diffsync/adapters/netbox.py
+++ b/nautobot_netbox_importer/diffsync/adapters/netbox.py
@@ -23,8 +23,19 @@ from nautobot_netbox_importer.generator import SourceDataGenerator
 from nautobot_netbox_importer.generator import SourceRecord
 from nautobot_netbox_importer.summary import Pathable
 
-_FileRef = Union[str, Path, ParseResult]
+for _name in (
+    "base",
+    "circuits",
+    "custom_fields",
+    "dcim",
+    "ipam",
+    "locations",
+    "object_change",
+    "virtualization",
+):
+    register_generator_setup(f"nautobot_netbox_importer.diffsync.models.{_name}")
 
+_FileRef = Union[str, Path, ParseResult]
 _HTTP_TIMEOUT = 60
 
 
@@ -51,9 +62,6 @@ class NetBoxImporterOptions(NamedTuple):
 
 
 AdapterSetupFunction = Callable[[SourceAdapter], None]
-
-for _name in ("base", "locations", "dcim", "circuits", "ipam", "virtualization"):
-    register_generator_setup(f"nautobot_netbox_importer.diffsync.models.{_name}")
 
 
 class NetBoxAdapter(SourceAdapter):

--- a/nautobot_netbox_importer/diffsync/models/custom_fields.py
+++ b/nautobot_netbox_importer/diffsync/models/custom_fields.py
@@ -1,0 +1,124 @@
+"""NetBox to Nautobot Custom Fields Models Mapping."""
+
+import json
+from typing import Any
+from typing import Iterable
+
+from nautobot_netbox_importer.base import RecordData
+from nautobot_netbox_importer.base import Uid
+from nautobot_netbox_importer.generator import EMPTY_VALUES
+from nautobot_netbox_importer.generator import DiffSyncBaseModel
+from nautobot_netbox_importer.generator import SourceAdapter
+from nautobot_netbox_importer.generator import SourceField
+
+
+def _convert_choices(choices: Any) -> list:
+    r"""Convert NetBox custom field choices to Nautobot format.
+
+    Example:
+        >>> _convert_choices("[\"[\\\"Choice 1\\\", \\\"Choice 1\\\"]\", \"[\\\"Choice 2\\\", \\\"Choice 2\\\"]\", \"[\\\"Choice 3\\\", \\\"Choice 3\\\"]\"]")
+        ["Choice 1", "Choice 2", "Choice 3"]
+    """
+    if choices in EMPTY_VALUES:
+        return []
+
+    if isinstance(choices, str):
+        choices = json.loads(choices)
+
+    if choices in EMPTY_VALUES:
+        return []
+
+    for index, choice in enumerate(choices):
+        if isinstance(choice, str):
+            try:
+                stringified = json.loads(choice)
+                if isinstance(stringified, (list, str)):
+                    choice = stringified
+            except json.JSONDecodeError:
+                choice = [choice, choice]
+
+        if isinstance(choice, Iterable):
+            if not isinstance(choice, list):
+                choice = list(choice)
+        else:
+            raise ValueError(f"Unsupported choices format: {choices}")
+
+        if len(choice) != 2:
+            raise ValueError(f"Unsupported choices format: {choices}")
+
+        choices[index] = choice[0]
+
+    return choices
+
+
+def setup(adapter: SourceAdapter) -> None:
+    """Map NetBox custom fields to Nautobot."""
+    choice_sets = {}
+
+    def create_choice_set(source: RecordData, stage: int) -> bool:
+        if stage != 1:
+            return True
+
+        choice_sets[source.get("id")] = [
+            *_convert_choices(source.get("base_choices")),
+            *_convert_choices(source.get("extra_choices")),
+        ]
+
+        return True
+
+    def define_choice_set(field: SourceField) -> None:
+        def choices_importer(source: RecordData, target: DiffSyncBaseModel) -> None:
+            choice_set = source.get(field.name, None)
+            if choice_set in EMPTY_VALUES:
+                return
+
+            choices = choice_sets.get(choice_set, None)
+            if not choices:
+                raise ValueError(f"Choice set {choice_set} not found")
+
+            create_choices(choices, getattr(target, "id"))
+
+        field.set_importer(choices_importer)
+
+    def define_choices(field: SourceField) -> None:
+        def choices_importer(source: RecordData, target: DiffSyncBaseModel) -> None:
+            choices = _convert_choices(source.get(field.name, None))
+            if choices in EMPTY_VALUES:
+                return
+
+            if not isinstance(choices, list):
+                raise ValueError(f"Choices must be a list of strings, got {type(choices)}")
+
+            create_choices(choices, getattr(target, "id"))
+
+        field.set_importer(choices_importer)
+
+    def create_choices(choices: list, custom_field_uid: Uid) -> None:
+        for choice in choices:
+            choices_wrapper.import_record(
+                {
+                    "id": choice,
+                    "custom_field": custom_field_uid,
+                    "value": choice,
+                },
+            )
+
+    adapter.configure_model(
+        "extras.CustomFieldChoiceSet",
+        pre_import=create_choice_set,
+    )
+    adapter.configure_model(
+        "extras.CustomField",
+        fields={
+            "name": "key",
+            "choices": define_choices,
+            "choice_set": define_choice_set,
+        },
+    )
+    choices_wrapper = adapter.configure_model(
+        "extras.CustomFieldChoice",
+        fields={
+            "custom_field": "custom_field",
+            "value": "value",
+        },
+    )

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from nautobot_netbox_importer.base import RecordData
 from nautobot_netbox_importer.generator import EMPTY_VALUES
 from nautobot_netbox_importer.generator import DiffSyncBaseModel
+from nautobot_netbox_importer.generator import PreImportResult
 from nautobot_netbox_importer.generator import SourceAdapter
 from nautobot_netbox_importer.generator import SourceField
 from nautobot_netbox_importer.generator import fields
@@ -32,13 +33,13 @@ def _define_units(field: SourceField) -> None:
     field.set_importer(units_importer)
 
 
-def _pre_import_cable_termination(source: RecordData, _) -> bool:
+def _pre_import_cable_termination(source: RecordData, _) -> PreImportResult:
     cable_end = source.pop("cable_end").lower()
     source["id"] = source.pop("cable")
     source[f"termination_{cable_end}_type"] = source.pop("termination_type")
     source[f"termination_{cable_end}_id"] = source.pop("termination_id")
 
-    return True
+    return PreImportResult.USE_RECORD
 
 
 def setup(adapter: SourceAdapter) -> None:

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -32,11 +32,13 @@ def _define_units(field: SourceField) -> None:
     field.set_importer(units_importer)
 
 
-def _pre_import_cable_termination(source: RecordData) -> None:
+def _pre_import_cable_termination(source: RecordData, _) -> bool:
     cable_end = source.pop("cable_end").lower()
     source["id"] = source.pop("cable")
     source[f"termination_{cable_end}_type"] = source.pop("termination_type")
     source[f"termination_{cable_end}_id"] = source.pop("termination_id")
+
+    return True
 
 
 def setup(adapter: SourceAdapter) -> None:

--- a/nautobot_netbox_importer/diffsync/models/object_change.py
+++ b/nautobot_netbox_importer/diffsync/models/object_change.py
@@ -1,6 +1,8 @@
 """NetBox to Nautobot Object Change Model Mapping."""
 
 from nautobot_netbox_importer.base import RecordData
+from nautobot_netbox_importer.generator import ImporterPass
+from nautobot_netbox_importer.generator import PreImportResult
 from nautobot_netbox_importer.generator import SourceAdapter
 from nautobot_netbox_importer.generator import fields
 
@@ -8,13 +10,13 @@ from nautobot_netbox_importer.generator import fields
 def setup(adapter: SourceAdapter) -> None:
     """Map NetBox object change to Nautobot."""
 
-    def skip_disabled_object_types(source: RecordData, stage: int) -> bool:
+    def skip_disabled_object_types(source: RecordData, importer_pass: ImporterPass) -> PreImportResult:
         """Disabled object types are not in Nautobot and should be skipped."""
-        if stage != 2:
-            return True
+        if importer_pass != ImporterPass.IMPORT_DATA:
+            return PreImportResult.USE_RECORD
         object_type = source.get("changed_object_type", None)
         wrapper = adapter.get_or_create_wrapper(object_type)
-        return not wrapper.disable_reason
+        return PreImportResult.SKIP_RECORD if wrapper.disable_reason else PreImportResult.USE_RECORD
 
     adapter.configure_model(
         "extras.ObjectChange",

--- a/nautobot_netbox_importer/diffsync/models/object_change.py
+++ b/nautobot_netbox_importer/diffsync/models/object_change.py
@@ -1,0 +1,28 @@
+"""NetBox to Nautobot Object Change Model Mapping."""
+
+from nautobot_netbox_importer.base import RecordData
+from nautobot_netbox_importer.generator import SourceAdapter
+from nautobot_netbox_importer.generator import fields
+
+
+def setup(adapter: SourceAdapter) -> None:
+    """Map NetBox object change to Nautobot."""
+
+    def skip_disabled_object_types(source: RecordData, stage: int) -> bool:
+        """Disabled object types are not in Nautobot and should be skipped."""
+        if stage != 2:
+            return True
+        object_type = source.get("changed_object_type", None)
+        wrapper = adapter.get_or_create_wrapper(object_type)
+        return not wrapper.disable_reason
+
+    adapter.configure_model(
+        "extras.ObjectChange",
+        pre_import=skip_disabled_object_types,
+        disable_related_reference=True,
+        fields={
+            "postchange_data": "object_data",
+            # TBD: This should be defined on Nautobot side
+            "time": fields.force(),
+        },
+    )

--- a/nautobot_netbox_importer/generator/__init__.py
+++ b/nautobot_netbox_importer/generator/__init__.py
@@ -4,6 +4,8 @@ from . import fields
 from .base import EMPTY_VALUES
 from .nautobot import NautobotAdapter
 from .source import DiffSyncBaseModel
+from .source import ImporterPass
+from .source import PreImportResult
 from .source import SourceAdapter
 from .source import SourceContentType
 from .source import SourceDataGenerator
@@ -16,7 +18,9 @@ from .source import SourceReferences
 __all__ = (
     "DiffSyncBaseModel",
     "EMPTY_VALUES",
+    "ImporterPass",
     "NautobotAdapter",
+    "PreImportResult",
     "SourceAdapter",
     "SourceContentType",
     "SourceDataGenerator",

--- a/nautobot_netbox_importer/generator/nautobot.py
+++ b/nautobot_netbox_importer/generator/nautobot.py
@@ -481,7 +481,7 @@ class NautobotModelWrapper:
         try:
             instance.save()
         except Exception:
-            logger.error("Save failed: %r %s", type(instance), instance.__dict__, exc_info=True)
+            logger.error("Save failed: %r %s", type(instance), instance.__dict__)
             raise
 
         if force_fields:

--- a/nautobot_netbox_importer/generator/source.py
+++ b/nautobot_netbox_importer/generator/source.py
@@ -271,7 +271,7 @@ class SourceAdapter(BaseAdapter):
                 wrapper = self.configure_model(content_type)
 
             if wrapper.pre_import:
-                if not wrapper.pre_import(data, ImporterPass.DEFINE_STRUCTURE):
+                if wrapper.pre_import(data, ImporterPass.DEFINE_STRUCTURE) != PreImportResult.USE_RECORD:
                     continue
 
             if wrapper.disable_reason:
@@ -297,7 +297,7 @@ class SourceAdapter(BaseAdapter):
             wrapper = self.wrappers[content_type]
 
             if wrapper.pre_import:
-                if not wrapper.pre_import(data, ImporterPass.IMPORT_DATA):
+                if wrapper.pre_import(data, ImporterPass.IMPORT_DATA) != PreImportResult.USE_RECORD:
                     wrapper.skipped_count += 1
                     continue
 

--- a/nautobot_netbox_importer/generator/source.py
+++ b/nautobot_netbox_importer/generator/source.py
@@ -55,6 +55,8 @@ class SourceRecord(NamedTuple):
     data: RecordData
 
 
+# The second argument is a stage number described in the documentation.
+PreImport = Callable[[RecordData, int], bool]
 SourceDataGenerator = Callable[[], Iterable[SourceRecord]]
 SourceFieldImporter = Callable[[RecordData, DiffSyncBaseModel], None]
 SourceFieldImporterFactory = Callable[["SourceField"], None]
@@ -106,7 +108,7 @@ class SourceAdapter(BaseAdapter):
         default_reference: Optional[RecordData] = None,
         flags: Optional[DiffSyncModelFlags] = None,
         nautobot_flags: Optional[DiffSyncModelFlags] = None,
-        pre_import: Optional[Callable[[RecordData], None]] = None,
+        pre_import: Optional[PreImport] = None,
         disable_related_reference: Optional[bool] = None,
         forward_references: Optional[ForwardReferences] = None,
     ) -> "SourceModelWrapper":
@@ -254,11 +256,13 @@ class SourceAdapter(BaseAdapter):
             else:
                 wrapper = self.configure_model(content_type)
 
+            if wrapper.pre_import:
+                if not wrapper.pre_import(data, 1):
+                    continue
+
             if wrapper.disable_reason:
                 continue
 
-            if wrapper.pre_import:
-                wrapper.pre_import(data)
             for field_name in data.keys():
                 wrapper.add_field(field_name, field_name, from_data=True)
 
@@ -277,6 +281,12 @@ class SourceAdapter(BaseAdapter):
         # Second pass to import actual data
         for content_type, data in get_source_data():
             wrapper = self.wrappers[content_type]
+
+            if wrapper.pre_import:
+                if not wrapper.pre_import(data, 2):
+                    wrapper.skipped_count += 1
+                    continue
+
             if not wrapper.disable_reason:
                 wrapper.import_record(data)
 
@@ -354,11 +364,12 @@ class SourceModelWrapper:
         self._cached_data: Dict[Uid, RecordData] = {}
 
         self.imported_count = 0
+        self.skipped_count = 0
         self.flags = DiffSyncModelFlags.NONE
 
         # Source fields defintions
         self.fields: OrderedDict[FieldName, SourceField] = OrderedDict()
-        self.pre_import: Optional[Callable[[RecordData], None]] = None
+        self.pre_import: Optional[PreImport] = None
 
         if self.disable_reason:
             self.adapter.logger.debug("Created disabled %s", self)
@@ -398,6 +409,7 @@ class SourceModelWrapper:
             nautobot_flags=str(self.nautobot.flags),
             default_reference_uid=serialize_to_summary(self.default_reference_uid),
             imported_count=self.imported_count,
+            skipped_count=self.skipped_count,
         )
 
     def set_identifiers(self, identifiers: Iterable[FieldName]) -> None:
@@ -524,9 +536,6 @@ class SourceModelWrapper:
         self.adapter.logger.debug("Importing record %s %s", self, data)
         if self.importers is None:
             raise RuntimeError(f"Importers not created for {self}")
-
-        if self.pre_import:
-            self.pre_import(data)
 
         uid = self.get_pk_from_data(data)
         if not target:

--- a/nautobot_netbox_importer/summary.py
+++ b/nautobot_netbox_importer/summary.py
@@ -62,6 +62,7 @@ class ModelSummary(NamedTuple):
     nautobot_flags: str
     default_reference_uid: Union[str, bool, int, float, None]
     imported_count: int
+    skipped_count: int
 
 
 _FILL_UP_LENGTH = 100

--- a/nautobot_netbox_importer/tests/fixtures/3.0/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.0/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -96,6 +98,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -128,6 +131,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -302,6 +306,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -500,6 +505,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -734,6 +740,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -836,6 +843,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "account": {
                     "name": "account",
@@ -998,6 +1006,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1115,6 +1124,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 87,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1169,6 +1179,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1391,6 +1402,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1421,6 +1433,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1451,6 +1464,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 33,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -1661,6 +1675,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1787,6 +1802,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1817,6 +1833,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1847,6 +1864,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2201,6 +2219,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 28,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2339,6 +2358,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2369,6 +2389,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2507,6 +2528,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 13,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2705,6 +2727,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -2927,6 +2950,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3089,6 +3113,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1113,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -3407,6 +3432,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 267,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3545,6 +3571,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3623,6 +3650,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -3821,6 +3849,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -3947,6 +3976,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4049,6 +4079,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4187,6 +4218,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -4457,6 +4489,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -4679,6 +4712,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -4829,6 +4863,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4943,6 +4978,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 53,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -5165,6 +5201,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 20,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5315,6 +5352,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5609,6 +5647,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5651,6 +5690,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -5777,6 +5817,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_cable_peer_id": {
                     "name": "_cable_peer_id",
@@ -5987,6 +6028,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6137,6 +6179,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -6323,6 +6366,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6665,6 +6709,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -6779,6 +6824,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -6809,6 +6855,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -6839,6 +6886,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -6846,7 +6894,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -6858,7 +6906,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -7061,6 +7109,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -7100,6 +7149,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 68,
@@ -7115,6 +7182,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7145,6 +7213,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7175,6 +7244,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7205,6 +7275,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7235,6 +7306,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7260,11 +7332,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7319,6 +7392,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -7336,6 +7410,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7378,6 +7453,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -7397,6 +7473,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7451,6 +7528,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7493,6 +7571,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -7559,6 +7638,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7589,6 +7669,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7727,6 +7808,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7769,6 +7851,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7823,6 +7906,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -7840,6 +7924,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 68,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -8074,6 +8159,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8188,6 +8274,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8326,6 +8413,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8356,6 +8444,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8386,6 +8475,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8572,6 +8662,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8698,6 +8789,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8728,6 +8820,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -8745,6 +8838,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -8762,6 +8856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -8779,6 +8874,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -8796,6 +8892,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -8826,6 +8923,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8856,6 +8954,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8886,6 +8985,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -9012,6 +9112,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9174,6 +9275,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9204,6 +9306,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -9221,6 +9324,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9251,6 +9355,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9281,6 +9386,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -9298,6 +9404,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -9460,6 +9567,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9562,6 +9670,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9664,6 +9773,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -9898,6 +10008,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",

--- a/nautobot_netbox_importer/tests/fixtures/3.0/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.0/summary.txt
@@ -119,6 +119,7 @@ dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
@@ -710,6 +711,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/fixtures/3.1/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.1/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -108,6 +110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -140,6 +143,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -314,6 +318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -512,6 +517,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -746,6 +752,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -848,6 +855,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "account": {
                     "name": "account",
@@ -1010,6 +1018,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1127,6 +1136,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1181,6 +1191,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1415,6 +1426,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1445,6 +1457,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1475,6 +1488,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 41,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -1685,6 +1699,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1811,6 +1826,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1841,6 +1857,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1871,6 +1888,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2237,6 +2255,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2375,6 +2394,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2489,6 +2509,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2627,6 +2648,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "airflow": {
                     "name": "airflow",
@@ -2837,6 +2859,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -3059,6 +3082,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3221,6 +3245,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1554,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -3647,6 +3672,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 268,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3785,6 +3811,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3863,6 +3890,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4073,6 +4101,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -4199,6 +4228,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4301,6 +4331,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4439,6 +4470,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -4709,6 +4741,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -4931,6 +4964,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5081,6 +5115,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -5195,6 +5230,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 75,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -5417,6 +5453,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5567,6 +5604,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5861,6 +5899,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -5987,6 +6026,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -6113,6 +6153,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -6323,6 +6364,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6473,6 +6515,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -6659,6 +6702,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -7013,6 +7057,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7199,6 +7244,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7301,6 +7347,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -7318,6 +7365,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7348,6 +7396,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -7365,6 +7414,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -7372,7 +7422,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -7384,7 +7434,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -7587,6 +7637,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -7626,6 +7677,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 78,
@@ -7641,6 +7710,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7671,6 +7741,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7701,6 +7772,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7731,6 +7803,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7761,6 +7834,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7786,11 +7860,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7845,6 +7920,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -7862,6 +7938,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7904,6 +7981,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -7923,6 +8001,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7977,6 +8056,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8091,6 +8171,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -8157,6 +8238,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8187,6 +8269,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8325,6 +8408,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -8342,6 +8426,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8384,6 +8469,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -8401,6 +8487,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 30,
+            "skipped_count": 0,
             "fields": {
                 "address": {
                     "name": "address",
@@ -8587,6 +8674,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -8604,6 +8692,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 69,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -8838,6 +8927,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8952,6 +9042,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -9090,6 +9181,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9120,6 +9212,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9150,6 +9243,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9336,6 +9430,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9462,6 +9557,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9492,6 +9588,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -9509,6 +9606,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -9526,6 +9624,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -9543,6 +9642,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -9560,6 +9660,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -9590,6 +9691,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9620,6 +9722,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9650,6 +9753,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9680,6 +9784,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9710,6 +9815,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9740,6 +9846,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9770,6 +9877,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9800,6 +9908,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -9817,6 +9926,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -9834,6 +9944,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -9851,6 +9962,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -9868,6 +9980,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -9994,6 +10107,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10156,6 +10270,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10186,6 +10301,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -10203,6 +10319,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10233,6 +10350,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10263,6 +10381,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -10280,6 +10399,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10442,6 +10562,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10544,6 +10665,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10646,6 +10768,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -10880,6 +11003,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11102,6 +11226,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -11119,6 +11244,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -11136,6 +11262,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },

--- a/nautobot_netbox_importer/tests/fixtures/3.1/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.1/summary.txt
@@ -129,6 +129,7 @@ dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
 django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
 extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
@@ -774,6 +775,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/fixtures/3.2/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.2/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -108,6 +110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -140,6 +143,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -314,6 +318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -512,6 +517,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -746,6 +752,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -848,6 +855,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "account": {
                     "name": "account",
@@ -1022,6 +1030,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1151,6 +1160,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 111,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1205,6 +1215,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1439,6 +1450,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1469,6 +1481,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1499,6 +1512,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 41,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -1721,6 +1735,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1859,6 +1874,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1889,6 +1905,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1919,6 +1936,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2285,6 +2303,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2423,6 +2442,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2537,6 +2557,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2675,6 +2696,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "airflow": {
                     "name": "airflow",
@@ -2885,6 +2907,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -3119,6 +3142,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3293,6 +3317,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1586,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -3767,6 +3792,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 300,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3917,6 +3943,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3995,6 +4022,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.inventoryitemtemplate": {
@@ -4012,6 +4040,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.location": {
@@ -4029,6 +4058,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4239,6 +4269,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -4365,6 +4396,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4467,6 +4499,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebay": {
@@ -4484,6 +4517,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebaytemplate": {
@@ -4501,6 +4535,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.moduletype": {
@@ -4518,6 +4553,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.platform": {
@@ -4535,6 +4571,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4673,6 +4710,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -4943,6 +4981,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -5177,6 +5216,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5339,6 +5379,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -5453,6 +5494,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 75,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -5687,6 +5729,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5849,6 +5892,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6143,6 +6187,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -6269,6 +6314,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -6395,6 +6441,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_link_peer_id": {
                     "name": "_link_peer_id",
@@ -6617,6 +6664,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6779,6 +6827,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -6965,6 +7014,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -7271,6 +7321,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7457,6 +7508,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7559,6 +7611,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -7576,6 +7629,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7606,6 +7660,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -7623,6 +7678,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -7630,7 +7686,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -7642,7 +7698,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -7857,6 +7913,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -7896,6 +7953,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 85,
@@ -7911,6 +7986,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7941,6 +8017,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7971,6 +8048,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8001,6 +8079,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8031,6 +8110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8056,11 +8136,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8115,6 +8196,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -8132,6 +8214,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8174,6 +8257,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -8193,6 +8277,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8247,6 +8332,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8361,6 +8447,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -8427,6 +8514,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8457,6 +8545,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8595,6 +8684,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -8612,6 +8702,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8654,6 +8745,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -8671,6 +8763,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "address": {
                     "name": "address",
@@ -8857,6 +8950,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -8874,6 +8968,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 90,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -9108,6 +9203,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9222,6 +9318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -9360,6 +9457,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 12,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9462,6 +9560,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9492,6 +9591,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.vlan": {
@@ -9509,6 +9609,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9695,6 +9796,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9845,6 +9947,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9995,6 +10098,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -10012,6 +10116,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -10029,6 +10134,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -10046,6 +10152,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -10063,6 +10170,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -10093,6 +10201,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10123,6 +10232,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10153,6 +10263,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10183,6 +10294,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10213,6 +10325,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10243,6 +10356,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10273,6 +10387,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10303,6 +10418,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -10320,6 +10436,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -10337,6 +10454,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -10354,6 +10472,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -10371,6 +10490,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10497,6 +10617,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10659,6 +10780,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10689,6 +10811,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -10706,6 +10829,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10736,6 +10860,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10766,6 +10891,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -10783,6 +10909,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10945,6 +11072,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11047,6 +11175,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11149,6 +11278,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11383,6 +11513,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11617,6 +11748,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -11634,6 +11766,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -11651,6 +11784,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },

--- a/nautobot_netbox_importer/tests/fixtures/3.2/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.2/summary.txt
@@ -137,6 +137,7 @@ dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
 django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
 extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
@@ -809,6 +810,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/fixtures/3.3/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.3/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -108,6 +110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -140,6 +143,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -314,6 +318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -524,6 +529,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "cable": {
                     "name": "cable",
@@ -758,6 +764,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -860,6 +867,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "account": {
                     "name": "account",
@@ -1034,6 +1042,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1163,6 +1172,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 114,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1217,6 +1227,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1379,6 +1390,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1409,6 +1421,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 216,
+            "skipped_count": 0,
             "fields": {
                 "_device": {
                     "name": "_device",
@@ -1535,6 +1548,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 41,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1745,6 +1759,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1883,6 +1898,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1913,6 +1929,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1943,6 +1960,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2309,6 +2327,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2447,6 +2466,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2561,6 +2581,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2699,6 +2720,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "airflow": {
                     "name": "airflow",
@@ -2909,6 +2931,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3131,6 +3154,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3305,6 +3329,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1586,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3791,6 +3816,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 300,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3965,6 +3991,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4043,6 +4070,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.inventoryitemtemplate": {
@@ -4060,6 +4088,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.location": {
@@ -4077,6 +4106,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4287,6 +4317,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -4413,6 +4444,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4515,6 +4547,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebay": {
@@ -4532,6 +4565,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebaytemplate": {
@@ -4549,6 +4583,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.moduletype": {
@@ -4566,6 +4601,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.platform": {
@@ -4583,6 +4619,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4721,6 +4758,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_path": {
                     "name": "_path",
@@ -4979,6 +5017,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5201,6 +5240,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5363,6 +5403,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -5477,6 +5518,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 75,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5699,6 +5741,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5861,6 +5904,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6155,6 +6199,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -6281,6 +6326,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -6407,6 +6453,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6617,6 +6664,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6779,6 +6827,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -6965,6 +7014,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -7271,6 +7321,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7457,6 +7508,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7559,6 +7611,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -7576,6 +7629,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7606,6 +7660,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -7623,6 +7678,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -7630,7 +7686,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -7642,7 +7698,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -7881,6 +7937,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -7920,6 +7977,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 85,
@@ -7935,6 +8010,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7965,6 +8041,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7995,6 +8072,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8025,6 +8103,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8055,6 +8134,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8080,11 +8160,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8139,6 +8220,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -8156,6 +8238,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8198,6 +8281,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -8217,6 +8301,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8271,6 +8356,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8385,6 +8471,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -8451,6 +8538,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8481,6 +8569,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -8619,6 +8708,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -8636,6 +8726,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8678,6 +8769,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -8695,6 +8787,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "address": {
                     "name": "address",
@@ -8881,6 +8974,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpn": {
@@ -8898,6 +8992,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpntermination": {
@@ -8915,6 +9010,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -8932,6 +9028,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 90,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -9166,6 +9263,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9280,6 +9378,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -9418,6 +9517,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 12,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9520,6 +9620,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9550,6 +9651,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.vlan": {
@@ -9567,6 +9669,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9753,6 +9856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9903,6 +10007,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10053,6 +10158,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -10070,6 +10176,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -10087,6 +10194,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -10104,6 +10212,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -10121,6 +10230,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -10151,6 +10261,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10181,6 +10292,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10211,6 +10323,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10241,6 +10354,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10271,6 +10385,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10301,6 +10416,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10331,6 +10447,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10361,6 +10478,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -10378,6 +10496,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -10395,6 +10514,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -10412,6 +10532,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -10429,6 +10550,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10555,6 +10677,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10717,6 +10840,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10747,6 +10871,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -10764,6 +10889,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10794,6 +10920,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10824,6 +10951,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -10841,6 +10969,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -11015,6 +11144,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11117,6 +11247,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11219,6 +11350,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11477,6 +11609,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11711,6 +11844,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -11728,6 +11862,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -11745,6 +11880,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },

--- a/nautobot_netbox_importer/tests/fixtures/3.3/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.3/summary.txt
@@ -138,6 +138,7 @@ dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
 django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
 extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
@@ -814,6 +815,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/fixtures/3.4/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.4/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -108,6 +110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -140,6 +143,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -314,6 +318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -524,6 +529,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "cable": {
                     "name": "cable",
@@ -758,6 +764,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -860,6 +867,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "account": {
                     "name": "account",
@@ -998,6 +1006,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1127,6 +1136,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 119,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1181,6 +1191,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1367,6 +1378,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1397,6 +1409,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 216,
+            "skipped_count": 0,
             "fields": {
                 "_device": {
                     "name": "_device",
@@ -1523,6 +1536,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 41,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1733,6 +1747,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1871,6 +1886,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1901,6 +1917,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1931,6 +1948,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2309,6 +2327,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2447,6 +2466,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2561,6 +2581,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2699,6 +2720,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "_abs_weight": {
                     "name": "_abs_weight",
@@ -2957,6 +2979,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3179,6 +3202,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3353,6 +3377,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1586,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3851,6 +3876,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 300,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -4025,6 +4051,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4103,6 +4130,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.inventoryitemtemplate": {
@@ -4120,6 +4148,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.location": {
@@ -4137,6 +4166,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4347,6 +4377,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -4473,6 +4504,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4575,6 +4607,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebay": {
@@ -4592,6 +4625,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebaytemplate": {
@@ -4609,6 +4643,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.moduletype": {
@@ -4626,6 +4661,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.platform": {
@@ -4643,6 +4679,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4781,6 +4818,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_path": {
                     "name": "_path",
@@ -5051,6 +5089,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5273,6 +5312,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5435,6 +5475,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -5573,6 +5614,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 75,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5795,6 +5837,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5957,6 +6000,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_abs_max_weight": {
                     "name": "_abs_max_weight",
@@ -6335,6 +6379,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -6473,6 +6518,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -6599,6 +6645,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6809,6 +6856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6971,6 +7019,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7157,6 +7206,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -7463,6 +7513,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7649,6 +7700,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -7775,6 +7827,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "django_rq.queue": {
@@ -7792,6 +7845,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.branch": {
@@ -7809,6 +7863,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.cachedvalue": {
@@ -7826,6 +7881,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -7843,6 +7899,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7873,6 +7930,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -7890,6 +7948,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -7897,7 +7956,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -7909,7 +7968,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -8160,6 +8219,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -8199,6 +8259,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 89,
@@ -8214,6 +8292,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8244,6 +8323,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8274,6 +8354,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8304,6 +8385,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8334,6 +8416,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8359,11 +8442,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8418,6 +8502,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -8435,6 +8520,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8477,6 +8563,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.script": {
@@ -8494,6 +8581,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.stagedchange": {
@@ -8511,6 +8599,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -8530,6 +8619,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8584,6 +8674,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8698,6 +8789,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -8764,6 +8856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8794,6 +8887,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -8944,6 +9038,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -8961,6 +9056,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9003,6 +9099,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -9020,6 +9117,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "address": {
                     "name": "address",
@@ -9218,6 +9316,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpn": {
@@ -9235,6 +9334,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpntermination": {
@@ -9252,6 +9352,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -9269,6 +9370,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 90,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -9515,6 +9617,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9629,6 +9732,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -9767,6 +9871,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 12,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -9881,6 +9986,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9911,6 +10017,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.vlan": {
@@ -9928,6 +10035,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10126,6 +10234,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10276,6 +10385,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10438,6 +10548,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -10455,6 +10566,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -10472,6 +10584,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -10489,6 +10602,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -10506,6 +10620,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -10536,6 +10651,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10566,6 +10682,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10596,6 +10713,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10626,6 +10744,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10656,6 +10775,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10686,6 +10806,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10716,6 +10837,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10746,6 +10868,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -10763,6 +10886,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -10780,6 +10904,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -10797,6 +10922,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -10814,6 +10940,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10940,6 +11067,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11102,6 +11230,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11132,6 +11261,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -11149,6 +11279,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11179,6 +11310,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11209,6 +11341,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -11226,6 +11359,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -11412,6 +11546,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11514,6 +11649,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11616,6 +11752,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11886,6 +12023,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -12120,6 +12258,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -12137,6 +12276,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -12154,6 +12294,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },

--- a/nautobot_netbox_importer/tests/fixtures/3.4/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.4/summary.txt
@@ -141,6 +141,7 @@ django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type
 extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
 extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
 extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
@@ -844,6 +845,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/fixtures/3.5/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.5/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -108,6 +110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -140,6 +143,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -314,6 +318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -536,6 +541,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "cable": {
                     "name": "cable",
@@ -770,6 +776,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -872,6 +879,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "asns": {
                     "name": "asns",
@@ -998,6 +1006,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1127,6 +1136,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 119,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1181,6 +1191,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1367,6 +1378,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1397,6 +1409,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 216,
+            "skipped_count": 0,
             "fields": {
                 "_device": {
                     "name": "_device",
@@ -1523,6 +1536,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 41,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1733,6 +1747,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1871,6 +1886,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1901,6 +1917,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1931,6 +1948,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2309,6 +2327,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2447,6 +2466,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2561,6 +2581,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2699,6 +2720,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "_abs_weight": {
                     "name": "_abs_weight",
@@ -2957,6 +2979,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3179,6 +3202,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3353,6 +3377,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1586,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3851,6 +3876,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 300,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -4049,6 +4075,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4127,6 +4154,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.inventoryitemtemplate": {
@@ -4144,6 +4172,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.location": {
@@ -4161,6 +4190,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4371,6 +4401,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -4497,6 +4528,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4599,6 +4631,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebay": {
@@ -4616,6 +4649,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebaytemplate": {
@@ -4633,6 +4667,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.moduletype": {
@@ -4650,6 +4685,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.platform": {
@@ -4667,6 +4703,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4805,6 +4842,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_path": {
                     "name": "_path",
@@ -5075,6 +5113,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5297,6 +5336,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5459,6 +5499,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -5597,6 +5638,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 75,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5819,6 +5861,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5981,6 +6024,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_abs_max_weight": {
                     "name": "_abs_max_weight",
@@ -6359,6 +6403,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -6497,6 +6542,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -6623,6 +6669,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6833,6 +6880,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6995,6 +7043,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7181,6 +7230,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -7487,6 +7537,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7673,6 +7724,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -7799,6 +7851,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "django_rq.queue": {
@@ -7816,6 +7869,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.branch": {
@@ -7833,6 +7887,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.cachedvalue": {
@@ -7850,6 +7905,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -7867,6 +7923,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7897,6 +7954,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -7914,6 +7972,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -7921,7 +7980,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -7933,7 +7992,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -8184,6 +8243,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -8223,6 +8283,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 89,
@@ -8238,6 +8316,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8268,6 +8347,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8298,6 +8378,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8328,6 +8409,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8358,6 +8440,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8383,11 +8466,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8442,6 +8526,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -8459,6 +8544,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8501,6 +8587,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.script": {
@@ -8518,6 +8605,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.stagedchange": {
@@ -8535,6 +8623,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -8554,6 +8643,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8608,6 +8698,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8722,6 +8813,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -8788,6 +8880,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8818,6 +8911,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -8968,6 +9062,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -8985,6 +9080,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9027,6 +9123,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -9044,6 +9141,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "address": {
                     "name": "address",
@@ -9242,6 +9340,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpn": {
@@ -9259,6 +9358,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpntermination": {
@@ -9276,6 +9376,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -9293,6 +9394,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 90,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -9539,6 +9641,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9653,6 +9756,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -9791,6 +9895,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 12,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -9905,6 +10010,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9935,6 +10041,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.vlan": {
@@ -9952,6 +10059,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10150,6 +10258,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10300,6 +10409,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10462,6 +10572,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -10479,6 +10590,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -10496,6 +10608,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -10513,6 +10626,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -10530,6 +10644,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -10560,6 +10675,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10590,6 +10706,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10620,6 +10737,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10650,6 +10768,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10680,6 +10799,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10710,6 +10830,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10740,6 +10861,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10770,6 +10892,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -10787,6 +10910,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -10804,6 +10928,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -10821,6 +10946,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -10838,6 +10964,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10964,6 +11091,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11126,6 +11254,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11156,6 +11285,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -11173,6 +11303,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11203,6 +11334,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11233,6 +11365,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -11250,6 +11383,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -11436,6 +11570,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11538,6 +11673,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11640,6 +11776,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11910,6 +12047,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -12144,6 +12282,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -12161,6 +12300,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -12178,6 +12318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },

--- a/nautobot_netbox_importer/tests/fixtures/3.5/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.5/summary.txt
@@ -141,6 +141,7 @@ django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type
 extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
 extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
 extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
@@ -846,6 +847,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/README.md
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/README.md
@@ -12,15 +12,21 @@ To dump and use data from a NetBox instance, run the following command:
     --natural-primary \
     --natural-foreign \
     --output=/tmp/netbox_data.json \
-    contenttypes.ContentType \
-    extras.CustomField \
     auth.Group \
     auth.User \
-    tenancy.TenantGroup \
-    tenancy.Tenant \
-    ipam.FHRPGroup \
+    contenttypes.ContentType \
+    dcim.Device \
+    dcim.DeviceRole \
+    dcim.DeviceType \
+    dcim.Manufacturer \
+    dcim.Site \
+    extras.CustomField \
+    extras.CustomFieldChoiceSet \
     extras.JournalEntry \
     extras.ObjectChange \
+    ipam.FHRPGroup \
+    tenancy.Tenant \
+    tenancy.TenantGroup \
 
 diff -u /tmp/netbox_data.json ./input.json
 mv /tmp/netbox_data.json ./input.json

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/input.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/input.json
@@ -1,5 +1,134 @@
 [
 {
+  "model": "auth.group",
+  "fields": {
+    "name": "Staff",
+    "permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "pbkdf2_sha256$600000$Q2GGLCelSTFx7I1KlhVayQ$SIsLg8jTvMWFSTUzaTCQFZxrXOS3Hr/flJatpCUxVIM=",
+    "last_login": "2024-02-14T12:19:29.761Z",
+    "is_superuser": true,
+    "username": "admin",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": true,
+    "is_active": true,
+    "date_joined": "2020-12-18T02:07:15.359Z",
+    "groups": [],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "pbkdf2_sha256$260000$gBi1K9FpA2NWj5dSvB6znV$zBALOmUvzUyYDaWRYLzVrRI1zG8h9Ad0gg7Qvg0v/UA=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "alice",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-30T15:51:08Z",
+    "groups": [
+      [
+        "Staff"
+      ]
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "pbkdf2_sha256$260000$JgEVc44FdXaM95n6Be3n7Y$/F2wz5QMuE3N+d7y33pC3T3UAqbM48cJE9kvev+8bbk=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "bob",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-30T15:51:16Z",
+    "groups": [
+      [
+        "Staff"
+      ]
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "pbkdf2_sha256$260000$0p4aoqQjuAqDTT7Bw38a3f$J1MJnsHPyQS5B/qZdiJwWqoVkolzklptsVvHwumSNxY=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "charlie",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-30T15:51:22Z",
+    "groups": [
+      [
+        "Staff"
+      ]
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "pbkdf2_sha256$260000$GBsMoAampVW1SJXxqW2QST$M5K+Kg7Q1YHhvX8aJnlqVqQCoPYAodeVPiHGrD5kpqE=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "danielle",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-30T15:51:40Z",
+    "groups": [
+      [
+        "Staff"
+      ]
+    ],
+    "user_permissions": []
+  }
+},
+{
+  "model": "auth.user",
+  "fields": {
+    "password": "pbkdf2_sha256$260000$OmfTtdffXUdO8KU20NV2st$SCU3bZf19U8QaovyDS/PY5joXvHllYUK7qULPxuoIsk=",
+    "last_login": null,
+    "is_superuser": false,
+    "username": "edward",
+    "first_name": "",
+    "last_name": "",
+    "email": "",
+    "is_staff": false,
+    "is_active": true,
+    "date_joined": "2021-12-30T15:51:50Z",
+    "groups": [
+      [
+        "Staff"
+      ]
+    ],
+    "user_permissions": []
+  }
+},
+{
   "model": "contenttypes.contenttype",
   "fields": {
     "app_label": "admin",
@@ -945,6 +1074,142 @@
   }
 },
 {
+  "model": "dcim.device",
+  "pk": 1,
+  "fields": {
+    "created": "2024-02-14T12:22:40.699Z",
+    "last_updated": "2024-02-14T12:23:00.279Z",
+    "custom_field_data": {
+      "device_custom_choices": "Choice 1"
+    },
+    "description": "",
+    "comments": "",
+    "local_context_data": null,
+    "config_template": null,
+    "device_type": 1,
+    "role": 1,
+    "tenant": null,
+    "platform": null,
+    "name": "Device 1",
+    "_name": "Device 00000001",
+    "serial": "",
+    "asset_tag": null,
+    "site": 1,
+    "location": null,
+    "rack": null,
+    "position": null,
+    "face": "",
+    "status": "active",
+    "airflow": "",
+    "primary_ip4": null,
+    "primary_ip6": null,
+    "oob_ip": null,
+    "cluster": null,
+    "virtual_chassis": null,
+    "vc_position": null,
+    "vc_priority": null,
+    "latitude": null,
+    "longitude": null,
+    "console_port_count": 0,
+    "console_server_port_count": 0,
+    "power_port_count": 0,
+    "power_outlet_count": 0,
+    "interface_count": 0,
+    "front_port_count": 0,
+    "rear_port_count": 0,
+    "device_bay_count": 0,
+    "module_bay_count": 0,
+    "inventory_item_count": 0
+  }
+},
+{
+  "model": "dcim.devicerole",
+  "pk": 1,
+  "fields": {
+    "created": "2024-02-14T12:20:27.082Z",
+    "last_updated": "2024-02-14T12:20:27.082Z",
+    "custom_field_data": {},
+    "name": "Default Device Role",
+    "slug": "default-device-role",
+    "description": "",
+    "color": "9e9e9e",
+    "vm_role": true,
+    "config_template": null
+  }
+},
+{
+  "model": "dcim.devicetype",
+  "pk": 1,
+  "fields": {
+    "created": "2024-02-14T12:21:37.922Z",
+    "last_updated": "2024-02-14T12:21:37.922Z",
+    "custom_field_data": {},
+    "description": "",
+    "comments": "",
+    "weight": null,
+    "weight_unit": "",
+    "_abs_weight": null,
+    "manufacturer": 1,
+    "model": "Device Model",
+    "slug": "device-model",
+    "default_platform": null,
+    "part_number": "",
+    "u_height": "1.0",
+    "is_full_depth": true,
+    "subdevice_role": "",
+    "airflow": "",
+    "front_image": "",
+    "rear_image": "",
+    "console_port_template_count": 0,
+    "console_server_port_template_count": 0,
+    "power_port_template_count": 0,
+    "power_outlet_template_count": 0,
+    "interface_template_count": 0,
+    "front_port_template_count": 0,
+    "rear_port_template_count": 0,
+    "device_bay_template_count": 0,
+    "module_bay_template_count": 0,
+    "inventory_item_template_count": 0
+  }
+},
+{
+  "model": "dcim.manufacturer",
+  "pk": 1,
+  "fields": {
+    "created": "2024-02-14T12:20:59.505Z",
+    "last_updated": "2024-02-14T12:20:59.505Z",
+    "custom_field_data": {},
+    "name": "Manufacturer",
+    "slug": "manufacturer",
+    "description": ""
+  }
+},
+{
+  "model": "dcim.site",
+  "pk": 1,
+  "fields": {
+    "created": "2024-02-14T12:22:26.202Z",
+    "last_updated": "2024-02-14T12:22:26.202Z",
+    "custom_field_data": {},
+    "description": "",
+    "comments": "",
+    "name": "Site 1",
+    "_name": "Site 00000001",
+    "slug": "site-1",
+    "status": "active",
+    "region": null,
+    "group": null,
+    "tenant": null,
+    "facility": "",
+    "time_zone": null,
+    "physical_address": "",
+    "shipping_address": "",
+    "latitude": null,
+    "longitude": null,
+    "asns": []
+  }
+},
+{
   "model": "extras.customfield",
   "pk": 1,
   "fields": {
@@ -976,341 +1241,85 @@
   }
 },
 {
-  "model": "auth.group",
-  "fields": {
-    "name": "Staff",
-    "permissions": []
-  }
-},
-{
-  "model": "auth.user",
-  "fields": {
-    "password": "pbkdf2_sha256$600000$Q2GGLCelSTFx7I1KlhVayQ$SIsLg8jTvMWFSTUzaTCQFZxrXOS3Hr/flJatpCUxVIM=",
-    "last_login": "2024-01-22T08:12:27.190Z",
-    "is_superuser": true,
-    "username": "admin",
-    "first_name": "",
-    "last_name": "",
-    "email": "",
-    "is_staff": true,
-    "is_active": true,
-    "date_joined": "2020-12-18T02:07:15.359Z",
-    "groups": [],
-    "user_permissions": []
-  }
-},
-{
-  "model": "auth.user",
-  "fields": {
-    "password": "pbkdf2_sha256$260000$gBi1K9FpA2NWj5dSvB6znV$zBALOmUvzUyYDaWRYLzVrRI1zG8h9Ad0gg7Qvg0v/UA=",
-    "last_login": null,
-    "is_superuser": false,
-    "username": "alice",
-    "first_name": "",
-    "last_name": "",
-    "email": "",
-    "is_staff": false,
-    "is_active": true,
-    "date_joined": "2021-12-30T15:51:08Z",
-    "groups": [
-      [
-        "Staff"
-      ]
-    ],
-    "user_permissions": []
-  }
-},
-{
-  "model": "auth.user",
-  "fields": {
-    "password": "pbkdf2_sha256$260000$JgEVc44FdXaM95n6Be3n7Y$/F2wz5QMuE3N+d7y33pC3T3UAqbM48cJE9kvev+8bbk=",
-    "last_login": null,
-    "is_superuser": false,
-    "username": "bob",
-    "first_name": "",
-    "last_name": "",
-    "email": "",
-    "is_staff": false,
-    "is_active": true,
-    "date_joined": "2021-12-30T15:51:16Z",
-    "groups": [
-      [
-        "Staff"
-      ]
-    ],
-    "user_permissions": []
-  }
-},
-{
-  "model": "auth.user",
-  "fields": {
-    "password": "pbkdf2_sha256$260000$0p4aoqQjuAqDTT7Bw38a3f$J1MJnsHPyQS5B/qZdiJwWqoVkolzklptsVvHwumSNxY=",
-    "last_login": null,
-    "is_superuser": false,
-    "username": "charlie",
-    "first_name": "",
-    "last_name": "",
-    "email": "",
-    "is_staff": false,
-    "is_active": true,
-    "date_joined": "2021-12-30T15:51:22Z",
-    "groups": [
-      [
-        "Staff"
-      ]
-    ],
-    "user_permissions": []
-  }
-},
-{
-  "model": "auth.user",
-  "fields": {
-    "password": "pbkdf2_sha256$260000$GBsMoAampVW1SJXxqW2QST$M5K+Kg7Q1YHhvX8aJnlqVqQCoPYAodeVPiHGrD5kpqE=",
-    "last_login": null,
-    "is_superuser": false,
-    "username": "danielle",
-    "first_name": "",
-    "last_name": "",
-    "email": "",
-    "is_staff": false,
-    "is_active": true,
-    "date_joined": "2021-12-30T15:51:40Z",
-    "groups": [
-      [
-        "Staff"
-      ]
-    ],
-    "user_permissions": []
-  }
-},
-{
-  "model": "auth.user",
-  "fields": {
-    "password": "pbkdf2_sha256$260000$OmfTtdffXUdO8KU20NV2st$SCU3bZf19U8QaovyDS/PY5joXvHllYUK7qULPxuoIsk=",
-    "last_login": null,
-    "is_superuser": false,
-    "username": "edward",
-    "first_name": "",
-    "last_name": "",
-    "email": "",
-    "is_staff": false,
-    "is_active": true,
-    "date_joined": "2021-12-30T15:51:50Z",
-    "groups": [
-      [
-        "Staff"
-      ]
-    ],
-    "user_permissions": []
-  }
-},
-{
-  "model": "tenancy.tenantgroup",
-  "pk": 1,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-19T02:43:53.309Z",
-    "custom_field_data": {},
-    "parent": null,
-    "description": "",
-    "name": "Customers",
-    "slug": "customers",
-    "lft": 1,
-    "rght": 2,
-    "tree_id": 1,
-    "level": 0
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 1,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:27.571Z",
-    "custom_field_data": {
-      "cust_id": "INI04"
-    },
-    "description": "",
-    "comments": "",
-    "name": "Initech",
-    "slug": "initech",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
+  "model": "extras.customfield",
   "pk": 2,
   "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:28.013Z",
-    "custom_field_data": {
-      "cust_id": "STR01"
-    },
+    "created": "2024-02-13T11:37:46.980Z",
+    "last_updated": "2024-02-13T11:37:46.980Z",
+    "type": "select",
+    "object_type": null,
+    "name": "device_custom_choices",
+    "label": "Device Custom Choices",
+    "group_name": "",
     "description": "",
-    "comments": "",
-    "name": "Strickland Propane",
-    "slug": "strickland-propane",
-    "group": 1
+    "required": false,
+    "search_weight": 1000,
+    "filter_logic": "loose",
+    "default": null,
+    "weight": 100,
+    "validation_minimum": null,
+    "validation_maximum": null,
+    "validation_regex": "",
+    "choice_set": 1,
+    "ui_visibility": "read-write",
+    "is_cloneable": false,
+    "content_types": [
+      [
+        "dcim",
+        "device"
+      ]
+    ]
   }
 },
 {
-  "model": "tenancy.tenant",
-  "pk": 3,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:27.776Z",
-    "custom_field_data": {
-      "cust_id": "PPI02"
-    },
-    "description": "",
-    "comments": "",
-    "name": "Pied Piper",
-    "slug": "pied-piper",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 4,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:27.927Z",
-    "custom_field_data": {
-      "cust_id": "STA03"
-    },
-    "description": "",
-    "comments": "",
-    "name": "Stark Industries",
-    "slug": "stark-industries",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 5,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2024-01-05T12:32:42.577Z",
-    "custom_field_data": {
-      "cust_id": "DMI01"
-    },
-    "description": "Test description",
-    "comments": "",
-    "name": "Dunder-Mifflin, Inc.",
-    "slug": "dunder-mifflin",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 6,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:28.158Z",
-    "custom_field_data": {
-      "cust_id": "WAY01"
-    },
-    "description": "",
-    "comments": "",
-    "name": "Wayne Enterprises",
-    "slug": "wayne-enterprises",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 7,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2024-01-05T12:32:23.202Z",
-    "custom_field_data": {
-      "cust_id": "CYB01"
-    },
-    "description": "Another test description",
-    "comments": "",
-    "name": "Cyberdyne Systems",
-    "slug": "cyberdyne",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 8,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:28.103Z",
-    "custom_field_data": {
-      "cust_id": "UMB01"
-    },
-    "description": "",
-    "comments": "",
-    "name": "Umbrella Corporation",
-    "slug": "umbrella",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 9,
-  "fields": {
-    "created": "2020-12-19T00:00:00Z",
-    "last_updated": "2020-12-30T18:43:27.631Z",
-    "custom_field_data": {
-      "cust_id": "YKY01"
-    },
-    "description": "",
-    "comments": "",
-    "name": "Nakatomi Corportation",
-    "slug": "nakatomi",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 10,
-  "fields": {
-    "created": "2021-03-10T00:00:00Z",
-    "last_updated": "2021-03-10T20:44:16.078Z",
-    "custom_field_data": {
-      "cust_id": ""
-    },
-    "description": "",
-    "comments": "",
-    "name": "Jimbob's Banking & Trust",
-    "slug": "jimbobs-banking-trust",
-    "group": 1
-  }
-},
-{
-  "model": "tenancy.tenant",
-  "pk": 13,
-  "fields": {
-    "created": "2021-04-02T00:00:00Z",
-    "last_updated": "2021-04-02T16:46:50.851Z",
-    "custom_field_data": {
-      "cust_id": ""
-    },
-    "description": "",
-    "comments": "",
-    "name": "NC State University",
-    "slug": "nc-state",
-    "group": 1
-  }
-},
-{
-  "model": "ipam.fhrpgroup",
+  "model": "extras.customfieldchoiceset",
   "pk": 1,
   "fields": {
-    "created": "2024-01-23T08:21:41.353Z",
-    "last_updated": "2024-01-23T08:21:41.353Z",
+    "created": "2024-02-13T11:36:15.523Z",
+    "last_updated": "2024-02-13T11:36:15.523Z",
+    "name": "DeviceChoiceSet",
+    "description": "",
+    "base_choices": "",
+    "extra_choices": "[\"[\\\"Choice 1\\\", \\\"Choice 1\\\"]\", \"[\\\"Choice 2\\\", \\\"Choice 2\\\"]\", \"[\\\"Choice 3\\\", \\\"Choice 3\\\"]\"]",
+    "order_alphabetically": false
+  }
+},
+{
+  "model": "extras.journalentry",
+  "pk": 1,
+  "fields": {
+    "created": "2024-01-22T08:22:44.596Z",
+    "last_updated": "2024-01-22T08:22:44.596Z",
     "custom_field_data": {},
-    "description": "FHR Group Description",
-    "comments": "FHR Group Comments",
-    "group_id": 2,
-    "name": "Test FHR Group",
-    "protocol": "vrrp3",
-    "auth_type": "md5",
-    "auth_key": ""
+    "assigned_object_type": [
+      "tenancy",
+      "tenant"
+    ],
+    "assigned_object_id": 5,
+    "created_by": [
+      "admin"
+    ],
+    "kind": "info",
+    "comments": "This is testing info journal entry 1"
+  }
+},
+{
+  "model": "extras.journalentry",
+  "pk": 2,
+  "fields": {
+    "created": "2024-01-22T08:32:30.376Z",
+    "last_updated": "2024-01-22T08:32:30.376Z",
+    "custom_field_data": {},
+    "assigned_object_type": [
+      "tenancy",
+      "tenant"
+    ],
+    "assigned_object_id": 5,
+    "created_by": [
+      "admin"
+    ],
+    "kind": "",
+    "comments": "This is testing info journal entry 2\r\n\r\nMulti-line entry."
   }
 },
 {
@@ -1665,41 +1674,628 @@
   }
 },
 {
-  "model": "extras.journalentry",
-  "pk": 1,
+  "model": "extras.objectchange",
+  "pk": 8,
   "fields": {
-    "created": "2024-01-22T08:22:44.596Z",
-    "last_updated": "2024-01-22T08:22:44.596Z",
-    "custom_field_data": {},
-    "assigned_object_type": [
-      "tenancy",
-      "tenant"
-    ],
-    "assigned_object_id": 5,
-    "created_by": [
+    "time": "2024-02-13T11:36:15.528Z",
+    "user": [
       "admin"
     ],
-    "kind": "info",
-    "comments": "This is testing info journal entry 1"
+    "user_name": "admin",
+    "request_id": "6c2fd529-f8d5-45e4-ac14-0967b5e94b4d",
+    "action": "create",
+    "changed_object_type": [
+      "extras",
+      "customfieldchoiceset"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "DeviceChoiceSet",
+    "prechange_data": null,
+    "postchange_data": {
+      "name": "DeviceChoiceSet",
+      "created": "2024-02-13T11:36:15.523Z",
+      "description": "",
+      "base_choices": "",
+      "last_updated": "2024-02-13T11:36:15.523Z",
+      "extra_choices": "[\"[\\\"Choice 1\\\", \\\"Choice 1\\\"]\", \"[\\\"Choice 2\\\", \\\"Choice 2\\\"]\", \"[\\\"Choice 3\\\", \\\"Choice 3\\\"]\"]",
+      "order_alphabetically": false
+    }
   }
 },
 {
-  "model": "extras.journalentry",
-  "pk": 2,
+  "model": "extras.objectchange",
+  "pk": 9,
   "fields": {
-    "created": "2024-01-22T08:32:30.376Z",
-    "last_updated": "2024-01-22T08:32:30.376Z",
-    "custom_field_data": {},
-    "assigned_object_type": [
-      "tenancy",
-      "tenant"
-    ],
-    "assigned_object_id": 5,
-    "created_by": [
+    "time": "2024-02-13T11:37:46.985Z",
+    "user": [
       "admin"
     ],
-    "kind": "",
-    "comments": "This is testing info journal entry 2\r\n\r\nMulti-line entry."
+    "user_name": "admin",
+    "request_id": "2b2ea50d-7b11-47d8-b3ab-6df841029284",
+    "action": "create",
+    "changed_object_type": [
+      "extras",
+      "customfield"
+    ],
+    "changed_object_id": 2,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Device Custom Choices",
+    "prechange_data": null,
+    "postchange_data": {
+      "name": "device_custom_choices",
+      "type": "select",
+      "label": "Device Custom Choices",
+      "weight": 100,
+      "created": "2024-02-13T11:37:46.980Z",
+      "default": null,
+      "required": false,
+      "choice_set": 1,
+      "group_name": "",
+      "description": "",
+      "object_type": null,
+      "filter_logic": "loose",
+      "is_cloneable": false,
+      "last_updated": "2024-02-13T11:37:46.980Z",
+      "content_types": [
+        32
+      ],
+      "search_weight": 1000,
+      "ui_visibility": "read-write",
+      "validation_regex": "",
+      "validation_maximum": null,
+      "validation_minimum": null
+    }
+  }
+},
+{
+  "model": "extras.objectchange",
+  "pk": 10,
+  "fields": {
+    "time": "2024-02-14T12:20:27.089Z",
+    "user": [
+      "admin"
+    ],
+    "user_name": "admin",
+    "request_id": "dad49be5-88ef-4de1-a061-d22e7f3201e3",
+    "action": "create",
+    "changed_object_type": [
+      "dcim",
+      "devicerole"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Default Device Role",
+    "prechange_data": null,
+    "postchange_data": {
+      "name": "Default Device Role",
+      "slug": "default-device-role",
+      "tags": [],
+      "color": "9e9e9e",
+      "created": "2024-02-14T12:20:27.082Z",
+      "vm_role": true,
+      "description": "",
+      "last_updated": "2024-02-14T12:20:27.082Z",
+      "custom_fields": {},
+      "config_template": null
+    }
+  }
+},
+{
+  "model": "extras.objectchange",
+  "pk": 11,
+  "fields": {
+    "time": "2024-02-14T12:20:59.512Z",
+    "user": [
+      "admin"
+    ],
+    "user_name": "admin",
+    "request_id": "f9d04078-9df0-47b4-b993-3293aac3af82",
+    "action": "create",
+    "changed_object_type": [
+      "dcim",
+      "manufacturer"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Manufacturer",
+    "prechange_data": null,
+    "postchange_data": {
+      "name": "Manufacturer",
+      "slug": "manufacturer",
+      "tags": [],
+      "created": "2024-02-14T12:20:59.505Z",
+      "description": "",
+      "last_updated": "2024-02-14T12:20:59.505Z",
+      "custom_fields": {}
+    }
+  }
+},
+{
+  "model": "extras.objectchange",
+  "pk": 12,
+  "fields": {
+    "time": "2024-02-14T12:21:37.925Z",
+    "user": [
+      "admin"
+    ],
+    "user_name": "admin",
+    "request_id": "f5047a81-7397-4eed-a293-87cfc38f05f6",
+    "action": "create",
+    "changed_object_type": [
+      "dcim",
+      "devicetype"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Device Model",
+    "prechange_data": null,
+    "postchange_data": {
+      "slug": "device-model",
+      "tags": [],
+      "model": "Device Model",
+      "weight": null,
+      "airflow": "",
+      "created": "2024-02-14T12:21:37.922Z",
+      "comments": "",
+      "u_height": "1",
+      "rear_image": "",
+      "description": "",
+      "front_image": "",
+      "part_number": "",
+      "weight_unit": "",
+      "last_updated": "2024-02-14T12:21:37.922Z",
+      "manufacturer": 1,
+      "custom_fields": {},
+      "is_full_depth": true,
+      "subdevice_role": "",
+      "default_platform": null,
+      "interface_template_count": 0,
+      "rear_port_template_count": 0,
+      "device_bay_template_count": 0,
+      "front_port_template_count": 0,
+      "module_bay_template_count": 0,
+      "power_port_template_count": 0,
+      "console_port_template_count": 0,
+      "power_outlet_template_count": 0,
+      "inventory_item_template_count": 0,
+      "console_server_port_template_count": 0
+    }
+  }
+},
+{
+  "model": "extras.objectchange",
+  "pk": 13,
+  "fields": {
+    "time": "2024-02-14T12:22:26.208Z",
+    "user": [
+      "admin"
+    ],
+    "user_name": "admin",
+    "request_id": "51ffe8d4-8ad1-4e19-ad2d-4b3ab46a6048",
+    "action": "create",
+    "changed_object_type": [
+      "dcim",
+      "site"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Site 1",
+    "prechange_data": null,
+    "postchange_data": {
+      "asns": [],
+      "name": "Site 1",
+      "slug": "site-1",
+      "tags": [],
+      "group": null,
+      "region": null,
+      "status": "active",
+      "tenant": null,
+      "created": "2024-02-14T12:22:26.202Z",
+      "comments": "",
+      "facility": "",
+      "latitude": null,
+      "longitude": null,
+      "time_zone": null,
+      "description": "",
+      "last_updated": "2024-02-14T12:22:26.202Z",
+      "custom_fields": {},
+      "physical_address": "",
+      "shipping_address": ""
+    }
+  }
+},
+{
+  "model": "extras.objectchange",
+  "pk": 14,
+  "fields": {
+    "time": "2024-02-14T12:22:40.704Z",
+    "user": [
+      "admin"
+    ],
+    "user_name": "admin",
+    "request_id": "7981ca97-ce3c-4381-88f5-b960e3116e7b",
+    "action": "create",
+    "changed_object_type": [
+      "dcim",
+      "device"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Device 1",
+    "prechange_data": null,
+    "postchange_data": {
+      "face": "",
+      "name": "Device 1",
+      "rack": null,
+      "role": 1,
+      "site": 1,
+      "tags": [],
+      "oob_ip": null,
+      "serial": "",
+      "status": "active",
+      "tenant": null,
+      "airflow": "",
+      "cluster": null,
+      "created": "2024-02-14T12:22:40.699Z",
+      "comments": "",
+      "latitude": null,
+      "location": null,
+      "platform": null,
+      "position": null,
+      "asset_tag": null,
+      "longitude": null,
+      "description": "",
+      "device_type": 1,
+      "primary_ip4": null,
+      "primary_ip6": null,
+      "vc_position": null,
+      "vc_priority": null,
+      "last_updated": "2024-02-14T12:22:40.699Z",
+      "custom_fields": {
+        "device_custom_choices": null
+      },
+      "config_template": null,
+      "interface_count": 0,
+      "rear_port_count": 0,
+      "virtual_chassis": null,
+      "device_bay_count": 0,
+      "front_port_count": 0,
+      "module_bay_count": 0,
+      "power_port_count": 0,
+      "console_port_count": 0,
+      "local_context_data": null,
+      "power_outlet_count": 0,
+      "inventory_item_count": 0,
+      "console_server_port_count": 0
+    }
+  }
+},
+{
+  "model": "extras.objectchange",
+  "pk": 15,
+  "fields": {
+    "time": "2024-02-14T12:23:00.285Z",
+    "user": [
+      "admin"
+    ],
+    "user_name": "admin",
+    "request_id": "5f62eec4-5501-443d-ba6d-7fdeabc6b00e",
+    "action": "update",
+    "changed_object_type": [
+      "dcim",
+      "device"
+    ],
+    "changed_object_id": 1,
+    "related_object_type": null,
+    "related_object_id": null,
+    "object_repr": "Device 1",
+    "prechange_data": {
+      "face": "",
+      "name": "Device 1",
+      "rack": null,
+      "role": 1,
+      "site": 1,
+      "tags": [],
+      "oob_ip": null,
+      "serial": "",
+      "status": "active",
+      "tenant": null,
+      "airflow": "",
+      "cluster": null,
+      "created": "2024-02-14T12:22:40.699Z",
+      "comments": "",
+      "latitude": null,
+      "location": null,
+      "platform": null,
+      "position": null,
+      "asset_tag": null,
+      "longitude": null,
+      "description": "",
+      "device_type": 1,
+      "primary_ip4": null,
+      "primary_ip6": null,
+      "vc_position": null,
+      "vc_priority": null,
+      "last_updated": "2024-02-14T12:22:40.699Z",
+      "custom_fields": {
+        "device_custom_choices": null
+      },
+      "config_template": null,
+      "interface_count": 0,
+      "rear_port_count": 0,
+      "virtual_chassis": null,
+      "device_bay_count": 0,
+      "front_port_count": 0,
+      "module_bay_count": 0,
+      "power_port_count": 0,
+      "console_port_count": 0,
+      "local_context_data": null,
+      "power_outlet_count": 0,
+      "inventory_item_count": 0,
+      "console_server_port_count": 0
+    },
+    "postchange_data": {
+      "face": "",
+      "name": "Device 1",
+      "rack": null,
+      "role": 1,
+      "site": 1,
+      "tags": [],
+      "oob_ip": null,
+      "serial": "",
+      "status": "active",
+      "tenant": null,
+      "airflow": "",
+      "cluster": null,
+      "created": "2024-02-14T12:22:40.699Z",
+      "comments": "",
+      "latitude": null,
+      "location": null,
+      "platform": null,
+      "position": null,
+      "asset_tag": null,
+      "longitude": null,
+      "description": "",
+      "device_type": 1,
+      "primary_ip4": null,
+      "primary_ip6": null,
+      "vc_position": null,
+      "vc_priority": null,
+      "last_updated": "2024-02-14T12:23:00.279Z",
+      "custom_fields": {
+        "device_custom_choices": "Choice 1"
+      },
+      "config_template": null,
+      "interface_count": 0,
+      "rear_port_count": 0,
+      "virtual_chassis": null,
+      "device_bay_count": 0,
+      "front_port_count": 0,
+      "module_bay_count": 0,
+      "power_port_count": 0,
+      "console_port_count": 0,
+      "local_context_data": null,
+      "power_outlet_count": 0,
+      "inventory_item_count": 0,
+      "console_server_port_count": 0
+    }
+  }
+},
+{
+  "model": "ipam.fhrpgroup",
+  "pk": 1,
+  "fields": {
+    "created": "2024-01-23T08:21:41.353Z",
+    "last_updated": "2024-01-23T08:21:41.353Z",
+    "custom_field_data": {},
+    "description": "FHR Group Description",
+    "comments": "FHR Group Comments",
+    "group_id": 2,
+    "name": "Test FHR Group",
+    "protocol": "vrrp3",
+    "auth_type": "md5",
+    "auth_key": ""
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 1,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:27.571Z",
+    "custom_field_data": {
+      "cust_id": "INI04"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Initech",
+    "slug": "initech",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 2,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:28.013Z",
+    "custom_field_data": {
+      "cust_id": "STR01"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Strickland Propane",
+    "slug": "strickland-propane",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 3,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:27.776Z",
+    "custom_field_data": {
+      "cust_id": "PPI02"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Pied Piper",
+    "slug": "pied-piper",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 4,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:27.927Z",
+    "custom_field_data": {
+      "cust_id": "STA03"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Stark Industries",
+    "slug": "stark-industries",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 5,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2024-01-05T12:32:42.577Z",
+    "custom_field_data": {
+      "cust_id": "DMI01"
+    },
+    "description": "Test description",
+    "comments": "",
+    "name": "Dunder-Mifflin, Inc.",
+    "slug": "dunder-mifflin",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 6,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:28.158Z",
+    "custom_field_data": {
+      "cust_id": "WAY01"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Wayne Enterprises",
+    "slug": "wayne-enterprises",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 7,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2024-01-05T12:32:23.202Z",
+    "custom_field_data": {
+      "cust_id": "CYB01"
+    },
+    "description": "Another test description",
+    "comments": "",
+    "name": "Cyberdyne Systems",
+    "slug": "cyberdyne",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 8,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:28.103Z",
+    "custom_field_data": {
+      "cust_id": "UMB01"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Umbrella Corporation",
+    "slug": "umbrella",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 9,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-30T18:43:27.631Z",
+    "custom_field_data": {
+      "cust_id": "YKY01"
+    },
+    "description": "",
+    "comments": "",
+    "name": "Nakatomi Corportation",
+    "slug": "nakatomi",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 10,
+  "fields": {
+    "created": "2021-03-10T00:00:00Z",
+    "last_updated": "2021-03-10T20:44:16.078Z",
+    "custom_field_data": {
+      "cust_id": ""
+    },
+    "description": "",
+    "comments": "",
+    "name": "Jimbob's Banking & Trust",
+    "slug": "jimbobs-banking-trust",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenant",
+  "pk": 13,
+  "fields": {
+    "created": "2021-04-02T00:00:00Z",
+    "last_updated": "2021-04-02T16:46:50.851Z",
+    "custom_field_data": {
+      "cust_id": ""
+    },
+    "description": "",
+    "comments": "",
+    "name": "NC State University",
+    "slug": "nc-state",
+    "group": 1
+  }
+},
+{
+  "model": "tenancy.tenantgroup",
+  "pk": 1,
+  "fields": {
+    "created": "2020-12-19T00:00:00Z",
+    "last_updated": "2020-12-19T02:43:53.309Z",
+    "custom_field_data": {},
+    "parent": null,
+    "description": "",
+    "name": "Customers",
+    "slug": "customers",
+    "lft": 1,
+    "rght": 2,
+    "tree_id": 1,
+    "level": 0
   }
 }
 ]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.device.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.device.json
@@ -1,0 +1,40 @@
+[
+{
+  "model": "dcim.device",
+  "pk": "f510c5ff-e1f8-5adc-9fb5-30bc5791b42e",
+  "fields": {
+    "created": "2024-02-14T12:22:40.699Z",
+    "last_updated": "2024-02-14T13:29:43.936Z",
+    "_custom_field_data": {
+      "device_custom_choices": "Choice 1"
+    },
+    "local_config_context_data": null,
+    "local_config_context_schema": null,
+    "local_config_context_data_owner_content_type": null,
+    "local_config_context_data_owner_object_id": null,
+    "device_type": "257dca9a-92d2-5f02-af45-4de316a47b71",
+    "status": "fb37b4d1-40ae-5d11-b8cd-46d3f9c25c14",
+    "role": "576a98b1-e59e-5b3f-8d76-05a75d293a1b",
+    "tenant": null,
+    "platform": null,
+    "name": "Device 1",
+    "_name": "Device 00000001",
+    "serial": "",
+    "asset_tag": null,
+    "location": "c75ebf9a-0f74-5c7f-982b-a1a42faf5b09",
+    "rack": null,
+    "position": null,
+    "face": "",
+    "primary_ip4": null,
+    "primary_ip6": null,
+    "cluster": null,
+    "virtual_chassis": null,
+    "device_redundancy_group": null,
+    "device_redundancy_group_priority": null,
+    "vc_position": null,
+    "vc_priority": null,
+    "comments": "",
+    "secrets_group": null
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.devicetype.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.devicetype.json
@@ -1,0 +1,20 @@
+[
+{
+  "model": "dcim.devicetype",
+  "pk": "257dca9a-92d2-5f02-af45-4de316a47b71",
+  "fields": {
+    "created": "2024-02-14T12:21:37.922Z",
+    "last_updated": "2024-02-14T13:29:43.927Z",
+    "_custom_field_data": {},
+    "manufacturer": "9568e4c1-fa0c-5c43-9606-e25166e67765",
+    "model": "Device Model",
+    "part_number": "",
+    "u_height": 1,
+    "is_full_depth": true,
+    "subdevice_role": "",
+    "front_image": "",
+    "rear_image": "",
+    "comments": ""
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.location.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.location.json
@@ -1,0 +1,29 @@
+[
+{
+  "model": "dcim.location",
+  "pk": "c75ebf9a-0f74-5c7f-982b-a1a42faf5b09",
+  "fields": {
+    "created": "2024-02-14T12:22:26.202Z",
+    "last_updated": "2024-02-14T13:29:43.895Z",
+    "_custom_field_data": {},
+    "parent": null,
+    "name": "Site 1",
+    "_name": "Site 00000001",
+    "location_type": "8fceb641-4563-5da8-9004-963f9ed1965a",
+    "status": "fb37b4d1-40ae-5d11-b8cd-46d3f9c25c14",
+    "tenant": null,
+    "description": "",
+    "facility": "",
+    "asn": null,
+    "time_zone": null,
+    "physical_address": "",
+    "shipping_address": "",
+    "latitude": null,
+    "longitude": null,
+    "contact_name": "",
+    "contact_phone": "",
+    "contact_email": "",
+    "comments": ""
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.locationtype.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.locationtype.json
@@ -1,0 +1,35 @@
+[
+{
+  "model": "dcim.locationtype",
+  "pk": "6003e66c-d3f2-5a36-9c06-5ee450898936",
+  "fields": {
+    "created": "2024-02-14T13:29:43.891Z",
+    "last_updated": "2024-02-14T13:29:43.891Z",
+    "_custom_field_data": {},
+    "parent": null,
+    "name": "Region",
+    "description": "",
+    "nestable": true,
+    "content_types": [
+      55
+    ]
+  }
+},
+{
+  "model": "dcim.locationtype",
+  "pk": "8fceb641-4563-5da8-9004-963f9ed1965a",
+  "fields": {
+    "created": "2024-02-14T13:29:43.887Z",
+    "last_updated": "2024-02-14T13:29:43.887Z",
+    "_custom_field_data": {},
+    "parent": "6003e66c-d3f2-5a36-9c06-5ee450898936",
+    "name": "Site",
+    "description": "",
+    "nestable": false,
+    "content_types": [
+      56,
+      42
+    ]
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.manufacturer.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/dcim.manufacturer.json
@@ -1,0 +1,13 @@
+[
+{
+  "model": "dcim.manufacturer",
+  "pk": "9568e4c1-fa0c-5c43-9606-e25166e67765",
+  "fields": {
+    "created": "2024-02-14T12:20:59.505Z",
+    "last_updated": "2024-02-14T13:29:43.956Z",
+    "_custom_field_data": {},
+    "name": "Manufacturer",
+    "description": ""
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/extras.customfieldchoice.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/extras.customfieldchoice.json
@@ -1,0 +1,35 @@
+[
+{
+  "model": "extras.customfieldchoice",
+  "pk": "5aaff02a-a3d8-537e-9134-070b2d7914a4",
+  "fields": {
+    "created": "2024-02-14T13:30:39.750Z",
+    "last_updated": "2024-02-14T13:30:39.750Z",
+    "custom_field": "ce3f1f06-1d2d-5fd2-8096-f86f691bccb7",
+    "value": "Choice 2",
+    "weight": 100
+  }
+},
+{
+  "model": "extras.customfieldchoice",
+  "pk": "7fac7672-9dd4-57df-a2bb-8f2f0f93bee9",
+  "fields": {
+    "created": "2024-02-14T13:30:39.749Z",
+    "last_updated": "2024-02-14T13:30:39.749Z",
+    "custom_field": "ce3f1f06-1d2d-5fd2-8096-f86f691bccb7",
+    "value": "Choice 1",
+    "weight": 100
+  }
+},
+{
+  "model": "extras.customfieldchoice",
+  "pk": "bb4a706e-6ab6-5016-bcd7-9c4d8a91e054",
+  "fields": {
+    "created": "2024-02-14T13:30:39.751Z",
+    "last_updated": "2024-02-14T13:30:39.751Z",
+    "custom_field": "ce3f1f06-1d2d-5fd2-8096-f86f691bccb7",
+    "value": "Choice 3",
+    "weight": 100
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/extras.role.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/samples/extras.role.json
@@ -1,0 +1,18 @@
+[
+{
+  "model": "extras.role",
+  "pk": "576a98b1-e59e-5b3f-8d76-05a75d293a1b",
+  "fields": {
+    "created": "2024-02-14T12:20:27.082Z",
+    "last_updated": "2024-02-14T13:29:43.884Z",
+    "_custom_field_data": {},
+    "name": "Default Device Role",
+    "color": "9e9e9e",
+    "description": "",
+    "weight": null,
+    "content_types": [
+      42
+    ]
+  }
+}
+]

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.json
@@ -1,6 +1,6 @@
 {
     "diff_summary": {
-        "create": 31,
+        "create": 50,
         "update": 0,
         "delete": 0,
         "no-change": 0,
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "admin.logentry": {
@@ -39,6 +40,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -71,6 +73,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -125,6 +128,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -157,6 +161,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -331,6 +336,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -409,6 +415,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -475,6 +482,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -505,6 +513,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -535,6 +544,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "circuits.providernetwork": {
@@ -552,6 +562,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -585,6 +596,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 135,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -639,6 +651,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "core.datafile": {
@@ -656,6 +669,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "core.datasource": {
@@ -673,6 +687,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "core.job": {
@@ -690,6 +705,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "core.managedfile": {
@@ -707,6 +723,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.cable": {
@@ -724,6 +741,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -766,6 +784,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -796,6 +815,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -826,6 +846,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -856,6 +877,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -886,6 +908,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -916,6 +939,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -945,8 +969,153 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 0,
+            "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
+                "_name": {
+                    "name": "_name",
+                    "nautobot_name": "_name",
+                    "nautobot_internal_type": "PrivateProperty",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "_name",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "airflow": {
+                    "name": "airflow",
+                    "nautobot_name": "airflow",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "airflow",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "asset_tag": {
+                    "name": "asset_tag",
+                    "nautobot_name": "asset_tag",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "asset_tag",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "cluster": {
+                    "name": "cluster",
+                    "nautobot_name": "cluster_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "cluster",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "comments": {
+                    "name": "comments",
+                    "nautobot_name": "comments",
+                    "nautobot_internal_type": "TextField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "comments",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "config_template": {
+                    "name": "config_template",
+                    "nautobot_name": "config_template",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "config_template",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "console_port_count": {
+                    "name": "console_port_count",
+                    "nautobot_name": "console_port_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "console_port_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "console_server_port_count": {
+                    "name": "console_server_port_count",
+                    "nautobot_name": "console_server_port_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "console_server_port_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "created": {
+                    "name": "created",
+                    "nautobot_name": "created",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": "datetime_importer",
+                    "definition": "created",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "custom_field_data": {
+                    "name": "custom_field_data",
+                    "nautobot_name": "custom_field_data",
+                    "nautobot_internal_type": "CustomFieldData",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "custom_field_data",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "description": {
+                    "name": "description",
+                    "nautobot_name": "description",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "description",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "device_bay_count": {
+                    "name": "device_bay_count",
+                    "nautobot_name": "device_bay_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "device_bay_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "device_role": {
                     "name": "device_role",
                     "nautobot_name": "role_id",
@@ -959,6 +1128,42 @@
                     "default_value": null,
                     "disable_reason": ""
                 },
+                "device_type": {
+                    "name": "device_type",
+                    "nautobot_name": "device_type_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "device_type",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
+                    "disable_reason": ""
+                },
+                "face": {
+                    "name": "face",
+                    "nautobot_name": "face",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "face",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "front_port_count": {
+                    "name": "front_port_count",
+                    "nautobot_name": "front_port_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "front_port_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "id": {
                     "name": "id",
                     "nautobot_name": "id",
@@ -966,8 +1171,68 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "interface_count": {
+                    "name": "interface_count",
+                    "nautobot_name": "interface_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "interface_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "inventory_item_count": {
+                    "name": "inventory_item_count",
+                    "nautobot_name": "inventory_item_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "inventory_item_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "nautobot_name": "last_updated",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": null,
+                    "definition": null,
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": "Last updated field is updated with each write"
+                },
+                "latitude": {
+                    "name": "latitude",
+                    "nautobot_name": "latitude",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "latitude",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "local_context_data": {
+                    "name": "local_context_data",
+                    "nautobot_name": "local_context_data",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "local_context_data",
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -978,8 +1243,152 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "longitude": {
+                    "name": "longitude",
+                    "nautobot_name": "longitude",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "longitude",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "module_bay_count": {
+                    "name": "module_bay_count",
+                    "nautobot_name": "module_bay_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "module_bay_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "name": {
+                    "name": "name",
+                    "nautobot_name": "name",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "name",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "oob_ip": {
+                    "name": "oob_ip",
+                    "nautobot_name": "oob_ip",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "oob_ip",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "platform": {
+                    "name": "platform",
+                    "nautobot_name": "platform_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "platform",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "position": {
+                    "name": "position",
+                    "nautobot_name": "position",
+                    "nautobot_internal_type": "PositiveSmallIntegerField",
+                    "nautobot_can_import": true,
+                    "importer": "integer_importer",
+                    "definition": "position",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "power_outlet_count": {
+                    "name": "power_outlet_count",
+                    "nautobot_name": "power_outlet_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "power_outlet_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "power_port_count": {
+                    "name": "power_port_count",
+                    "nautobot_name": "power_port_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "power_port_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "primary_ip4": {
+                    "name": "primary_ip4",
+                    "nautobot_name": "primary_ip4_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "primary_ip4",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "primary_ip6": {
+                    "name": "primary_ip6",
+                    "nautobot_name": "primary_ip6_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "primary_ip6",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "rack": {
+                    "name": "rack",
+                    "nautobot_name": "rack_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "rack",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "rear_port_count": {
+                    "name": "rear_port_count",
+                    "nautobot_name": "rear_port_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "rear_port_count",
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1002,8 +1411,20 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "serial": {
+                    "name": "serial",
+                    "nautobot_name": "serial",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "serial",
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1013,9 +1434,9 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1026,9 +1447,57 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
+                    "disable_reason": ""
+                },
+                "tenant": {
+                    "name": "tenant",
+                    "nautobot_name": "tenant_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "tenant",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "vc_position": {
+                    "name": "vc_position",
+                    "nautobot_name": "vc_position",
+                    "nautobot_internal_type": "PositiveSmallIntegerField",
+                    "nautobot_can_import": true,
+                    "importer": "integer_importer",
+                    "definition": "vc_position",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "vc_priority": {
+                    "name": "vc_priority",
+                    "nautobot_name": "vc_priority",
+                    "nautobot_internal_type": "PositiveSmallIntegerField",
+                    "nautobot_can_import": true,
+                    "importer": "integer_importer",
+                    "definition": "vc_priority",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "virtual_chassis": {
+                    "name": "virtual_chassis",
+                    "nautobot_name": "virtual_chassis_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "virtual_chassis",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
                     "disable_reason": ""
                 }
             }
@@ -1048,6 +1517,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1078,6 +1548,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1107,7 +1578,8 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 0,
+            "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -1116,9 +1588,21 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
                     "default_value": "9e9e9e",
+                    "disable_reason": ""
+                },
+                "config_template": {
+                    "name": "config_template",
+                    "nautobot_name": "config_template",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "config_template",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
                     "disable_reason": ""
                 },
                 "content_types": {
@@ -1133,6 +1617,42 @@
                     "default_value": null,
                     "disable_reason": ""
                 },
+                "created": {
+                    "name": "created",
+                    "nautobot_name": "created",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": "datetime_importer",
+                    "definition": "created",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "custom_field_data": {
+                    "name": "custom_field_data",
+                    "nautobot_name": "custom_field_data",
+                    "nautobot_internal_type": "CustomFieldData",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "custom_field_data",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "description": {
+                    "name": "description",
+                    "nautobot_name": "description",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "description",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "id": {
                     "name": "id",
                     "nautobot_name": "id",
@@ -1140,8 +1660,56 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "nautobot_name": "last_updated",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": null,
+                    "definition": null,
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": "Last updated field is updated with each write"
+                },
+                "name": {
+                    "name": "name",
+                    "nautobot_name": "name",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "name",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "slug": {
+                    "name": "slug",
+                    "nautobot_name": "slug",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "slug",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "vm_role": {
+                    "name": "vm_role",
+                    "nautobot_name": "vm_role",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "vm_role",
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1161,8 +1729,33 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
-            "imported_count": 0,
+            "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
+                "_abs_weight": {
+                    "name": "_abs_weight",
+                    "nautobot_name": "_abs_weight",
+                    "nautobot_internal_type": "PrivateProperty",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "_abs_weight",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "airflow": {
+                    "name": "airflow",
+                    "nautobot_name": "airflow",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "airflow",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "color": {
                     "name": "color",
                     "nautobot_name": "color",
@@ -1175,6 +1768,102 @@
                     "default_value": null,
                     "disable_reason": ""
                 },
+                "comments": {
+                    "name": "comments",
+                    "nautobot_name": "comments",
+                    "nautobot_internal_type": "TextField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "comments",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "console_port_template_count": {
+                    "name": "console_port_template_count",
+                    "nautobot_name": "console_port_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "console_port_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "console_server_port_template_count": {
+                    "name": "console_server_port_template_count",
+                    "nautobot_name": "console_server_port_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "console_server_port_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "created": {
+                    "name": "created",
+                    "nautobot_name": "created",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": "datetime_importer",
+                    "definition": "created",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "custom_field_data": {
+                    "name": "custom_field_data",
+                    "nautobot_name": "custom_field_data",
+                    "nautobot_internal_type": "CustomFieldData",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "custom_field_data",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "default_platform": {
+                    "name": "default_platform",
+                    "nautobot_name": "default_platform",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "default_platform",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "description": {
+                    "name": "description",
+                    "nautobot_name": "description",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "description",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "device_bay_template_count": {
+                    "name": "device_bay_template_count",
+                    "nautobot_name": "device_bay_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "device_bay_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "front_image": {
                     "name": "front_image",
                     "nautobot_name": null,
@@ -1182,10 +1871,22 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
+                },
+                "front_port_template_count": {
+                    "name": "front_port_template_count",
+                    "nautobot_name": "front_port_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "front_port_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
                 },
                 "id": {
                     "name": "id",
@@ -1198,6 +1899,54 @@
                     "is_custom": true,
                     "default_value": null,
                     "disable_reason": ""
+                },
+                "interface_template_count": {
+                    "name": "interface_template_count",
+                    "nautobot_name": "interface_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "interface_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "inventory_item_template_count": {
+                    "name": "inventory_item_template_count",
+                    "nautobot_name": "inventory_item_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "inventory_item_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "is_full_depth": {
+                    "name": "is_full_depth",
+                    "nautobot_name": "is_full_depth",
+                    "nautobot_internal_type": "BooleanField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "is_full_depth",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": true,
+                    "disable_reason": ""
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "nautobot_name": "last_updated",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": null,
+                    "definition": null,
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": "Last updated field is updated with each write"
                 },
                 "manufacturer": {
                     "name": "manufacturer",
@@ -1223,6 +1972,54 @@
                     "default_value": null,
                     "disable_reason": ""
                 },
+                "module_bay_template_count": {
+                    "name": "module_bay_template_count",
+                    "nautobot_name": "module_bay_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "module_bay_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "part_number": {
+                    "name": "part_number",
+                    "nautobot_name": "part_number",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "part_number",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "power_outlet_template_count": {
+                    "name": "power_outlet_template_count",
+                    "nautobot_name": "power_outlet_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "power_outlet_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "power_port_template_count": {
+                    "name": "power_port_template_count",
+                    "nautobot_name": "power_port_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "power_port_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "rear_image": {
                     "name": "rear_image",
                     "nautobot_name": null,
@@ -1230,10 +2027,82 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
+                },
+                "rear_port_template_count": {
+                    "name": "rear_port_template_count",
+                    "nautobot_name": "rear_port_template_count",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "rear_port_template_count",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "slug": {
+                    "name": "slug",
+                    "nautobot_name": "slug",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "slug",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "subdevice_role": {
+                    "name": "subdevice_role",
+                    "nautobot_name": "subdevice_role",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "subdevice_role",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "u_height": {
+                    "name": "u_height",
+                    "nautobot_name": "u_height",
+                    "nautobot_internal_type": "PositiveSmallIntegerField",
+                    "nautobot_can_import": true,
+                    "importer": "integer_importer",
+                    "definition": "u_height",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": 1,
+                    "disable_reason": ""
+                },
+                "weight": {
+                    "name": "weight",
+                    "nautobot_name": "weight",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "weight",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "weight_unit": {
+                    "name": "weight_unit",
+                    "nautobot_name": "weight_unit",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "weight_unit",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
                 }
             }
         },
@@ -1252,6 +2121,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1282,6 +2152,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1324,6 +2195,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1378,6 +2250,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1408,6 +2281,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1486,6 +2360,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.inventoryitemtemplate": {
@@ -1503,6 +2378,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.location": {
@@ -1520,6 +2396,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1645,7 +2522,8 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 0,
+            "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -1771,8 +2649,45 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
-            "imported_count": 0,
+            "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
+                "created": {
+                    "name": "created",
+                    "nautobot_name": "created",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": "datetime_importer",
+                    "definition": "created",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "custom_field_data": {
+                    "name": "custom_field_data",
+                    "nautobot_name": "custom_field_data",
+                    "nautobot_internal_type": "CustomFieldData",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "custom_field_data",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "description": {
+                    "name": "description",
+                    "nautobot_name": "description",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "description",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "id": {
                     "name": "id",
                     "nautobot_name": "id",
@@ -1785,6 +2700,18 @@
                     "default_value": null,
                     "disable_reason": ""
                 },
+                "last_updated": {
+                    "name": "last_updated",
+                    "nautobot_name": "last_updated",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": null,
+                    "definition": null,
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": "Last updated field is updated with each write"
+                },
                 "name": {
                     "name": "name",
                     "nautobot_name": "name",
@@ -1792,6 +2719,18 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "slug": {
+                    "name": "slug",
+                    "nautobot_name": "slug",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "slug",
                     "from_data": true,
                     "is_custom": false,
                     "default_value": null,
@@ -1814,6 +2753,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebay": {
@@ -1831,6 +2771,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebaytemplate": {
@@ -1848,6 +2789,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.moduletype": {
@@ -1865,6 +2807,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.platform": {
@@ -1882,6 +2825,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1912,6 +2856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1942,6 +2887,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1972,6 +2918,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2014,6 +2961,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2080,6 +3028,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2110,6 +3059,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2140,6 +3090,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2230,6 +3181,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2272,6 +3224,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2326,6 +3279,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2356,6 +3310,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2386,6 +3341,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2487,8 +3443,93 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 0,
+            "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
+                "_name": {
+                    "name": "_name",
+                    "nautobot_name": "_name",
+                    "nautobot_internal_type": "PrivateProperty",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "_name",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "asns": {
+                    "name": "asns",
+                    "nautobot_name": "asns",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "asns",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "comments": {
+                    "name": "comments",
+                    "nautobot_name": "comments",
+                    "nautobot_internal_type": "TextField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "comments",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "created": {
+                    "name": "created",
+                    "nautobot_name": "created",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": "datetime_importer",
+                    "definition": "created",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "custom_field_data": {
+                    "name": "custom_field_data",
+                    "nautobot_name": "custom_field_data",
+                    "nautobot_internal_type": "CustomFieldData",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "custom_field_data",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "description": {
+                    "name": "description",
+                    "nautobot_name": "description",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "description",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "facility": {
+                    "name": "facility",
+                    "nautobot_name": "facility",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "facility",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "group": {
                     "name": "group",
                     "nautobot_name": "location_type_id",
@@ -2496,7 +3537,7 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
                     "default_value": null,
                     "disable_reason": ""
@@ -2508,8 +3549,32 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "last_updated": {
+                    "name": "last_updated",
+                    "nautobot_name": "last_updated",
+                    "nautobot_internal_type": "DateTimeField",
+                    "nautobot_can_import": true,
+                    "importer": null,
+                    "definition": null,
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": "Last updated field is updated with each write"
+                },
+                "latitude": {
+                    "name": "latitude",
+                    "nautobot_name": "latitude",
+                    "nautobot_internal_type": "DecimalField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "latitude",
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2537,6 +3602,42 @@
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
+                "longitude": {
+                    "name": "longitude",
+                    "nautobot_name": "longitude",
+                    "nautobot_internal_type": "DecimalField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "longitude",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "name": {
+                    "name": "name",
+                    "nautobot_name": "name",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "name",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "physical_address": {
+                    "name": "physical_address",
+                    "nautobot_name": "physical_address",
+                    "nautobot_internal_type": "TextField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "physical_address",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "region": {
                     "name": "region",
                     "nautobot_name": "parent_id",
@@ -2544,7 +3645,7 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
+                    "from_data": true,
                     "is_custom": true,
                     "default_value": null,
                     "disable_reason": ""
@@ -2561,6 +3662,30 @@
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
+                "shipping_address": {
+                    "name": "shipping_address",
+                    "nautobot_name": "shipping_address",
+                    "nautobot_internal_type": "TextField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "shipping_address",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "slug": {
+                    "name": "slug",
+                    "nautobot_name": "slug",
+                    "nautobot_internal_type": "NotFound",
+                    "nautobot_can_import": false,
+                    "importer": null,
+                    "definition": "slug",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
                 "status": {
                     "name": "status",
                     "nautobot_name": "status_id",
@@ -2568,9 +3693,33 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "from_data": true,
+                    "is_custom": false,
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
+                    "disable_reason": ""
+                },
+                "tenant": {
+                    "name": "tenant",
+                    "nautobot_name": "tenant_id",
+                    "nautobot_internal_type": "ForeignKey",
+                    "nautobot_can_import": true,
+                    "importer": "relation_importer",
+                    "definition": "tenant",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
+                    "disable_reason": ""
+                },
+                "time_zone": {
+                    "name": "time_zone",
+                    "nautobot_name": "time_zone",
+                    "nautobot_internal_type": "CharField",
+                    "nautobot_can_import": true,
+                    "importer": "value_importer",
+                    "definition": "time_zone",
+                    "from_data": true,
+                    "is_custom": false,
+                    "default_value": null,
                     "disable_reason": ""
                 },
                 "tree_id": {
@@ -2602,6 +3751,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -2716,6 +3866,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2746,6 +3897,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "django_rq.queue": {
@@ -2763,6 +3915,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.bookmark": {
@@ -2780,6 +3933,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.branch": {
@@ -2797,6 +3951,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.cachedvalue": {
@@ -2814,6 +3969,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -2831,6 +3987,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -2861,6 +4018,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configtemplate": {
@@ -2878,6 +4036,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -2894,7 +4053,8 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 1,
+            "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -2902,7 +4062,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -2914,7 +4074,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -3176,7 +4336,8 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 0,
+            "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -3226,11 +4387,12 @@
             "identifiers": null,
             "disable_related_reference": false,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "create_choice_set",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customlink": {
@@ -3248,6 +4410,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3278,6 +4441,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.exporttemplate": {
@@ -3295,6 +4459,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3325,6 +4490,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3355,6 +4521,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -3385,6 +4552,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "assigned_object_id": {
                     "name": "assigned_object_id",
@@ -3506,11 +4674,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
-            "imported_count": 7,
+            "imported_count": 14,
+            "skipped_count": 1,
             "fields": {
                 "action": {
                     "name": "action",
@@ -3685,6 +4854,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.reportmodule": {
@@ -3702,6 +4872,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -3719,6 +4890,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -3761,6 +4933,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.script": {
@@ -3778,6 +4951,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.scriptmodule": {
@@ -3795,6 +4969,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.stagedchange": {
@@ -3812,6 +4987,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -3830,7 +5006,8 @@
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
-            "imported_count": 1,
+            "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -3885,6 +5062,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -3927,6 +5105,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -3993,6 +5172,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4023,6 +5203,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4065,6 +5246,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.asnrange": {
@@ -4082,6 +5264,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -4099,6 +5282,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "auth_key": {
                     "name": "auth_key",
@@ -4261,6 +5445,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -4278,6 +5463,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4332,6 +5518,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpn": {
@@ -4349,6 +5536,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpntermination": {
@@ -4366,6 +5554,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -4383,6 +5572,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4473,6 +5663,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4503,6 +5694,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -4557,6 +5749,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4587,6 +5780,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4617,6 +5811,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.vlan": {
@@ -4634,6 +5829,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "group": {
                     "name": "group",
@@ -4736,6 +5932,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4766,6 +5963,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4796,6 +5994,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -4813,6 +6012,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -4830,6 +6030,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -4847,6 +6048,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -4864,6 +6066,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -4894,6 +6097,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4924,6 +6128,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4954,6 +6159,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4984,6 +6190,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5014,6 +6221,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5044,6 +6252,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5074,6 +6283,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5104,6 +6314,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -5121,6 +6332,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -5138,6 +6350,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -5155,6 +6368,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -5172,6 +6386,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -5298,6 +6513,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -5460,6 +6676,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5490,6 +6707,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.netboxgroup": {
@@ -5507,6 +6725,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.netboxuser": {
@@ -5524,6 +6743,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -5541,6 +6761,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5571,6 +6792,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5601,6 +6823,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -5618,6 +6841,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "group": {
                     "name": "group",
@@ -5708,6 +6932,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5738,6 +6963,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5768,6 +6994,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5822,6 +7049,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -5876,6 +7104,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -5893,6 +7122,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -5910,8 +7140,17 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },
-    "validation_issues": {}
+    "validation_issues": {
+        "dcim.location": [
+            [
+                "c75ebf9a-0f74-5c7f-982b-a1a42faf5b09",
+                "Site 1",
+                "{'parent': ['A Location of type Site must have a parent Location.']}"
+            ]
+        ]
+    }
 }

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.txt
@@ -1,6 +1,6 @@
 = Import Summary: ==================================================================================
 - DiffSync Summary: --------------------------------------------------------------------------------
-create: 31
+create: 50
 update: 0
 delete: 0
 no-change: 0
@@ -9,15 +9,25 @@ skip: 135
 auth.group: 1
 auth.user: 6
 contenttypes.contenttype: 135
-extras.customfield: 1
+dcim.device: 1
+dcim.devicerole: 1
+dcim.devicetype: 1
+dcim.locationtype: 2
+dcim.manufacturer: 1
+dcim.site: 1
+extras.customfield: 2
+extras.customfieldchoice: 3
 extras.journalentry: 2
-extras.objectchange: 7
-extras.status: 1
+extras.objectchange: 14
+extras.status: 2
 ipam.fhrpgroup: 1
 tenancy.tenant: 11
 tenancy.tenantgroup: 1
 - Validation issues: -------------------------------------------------------------------------------
-  No validation issues found.
+. dcim.location: 1  ................................................................................
+c75ebf9a-0f74-5c7f-982b-a1a42faf5b09 Site 1 | {'parent': ['A Location of type Site must have a parent Location.']}
+. ..................................................................................................
+Total validation issues: 1
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
 account.usertoken => account.usertoken | Disabled with reason: Nautobot content type: `account.usertoken` not found
@@ -169,28 +179,98 @@ id (CUSTOM) => uid_from_data => id (UUIDField)
 * dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * dcim.device => dcim.device ***********************************************************************
+_name (DATA) => NO IMPORTER => NO TARGET
+airflow (DATA) => NO IMPORTER => NO TARGET
+asset_tag (DATA) => value_importer => asset_tag (CharField)
+cluster (DATA) => relation_importer => cluster_id (ForeignKey)
+comments (DATA) => value_importer => comments (TextField)
+config_template (DATA) => NO IMPORTER => NO TARGET
+console_port_count (DATA) => NO IMPORTER => NO TARGET
+console_server_port_count (DATA) => NO IMPORTER => NO TARGET
+created (DATA) => datetime_importer => created (DateTimeField)
+custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
+description (DATA) => NO IMPORTER => NO TARGET
+device_bay_count (DATA) => NO IMPORTER => NO TARGET
 device_role (CUSTOM) => relation_importer => role_id (RoleField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
+device_type (DATA) => relation_importer => device_type_id (ForeignKey)
+face (DATA) => value_importer => face (CharField)
+front_port_count (DATA) => NO IMPORTER => NO TARGET
+id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
+interface_count (DATA) => NO IMPORTER => NO TARGET
+inventory_item_count (DATA) => NO IMPORTER => NO TARGET
+last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
+latitude (DATA) => NO IMPORTER => NO TARGET
+local_context_data (DATA) => NO IMPORTER => NO TARGET
+location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
+longitude (DATA) => NO IMPORTER => NO TARGET
+module_bay_count (DATA) => NO IMPORTER => NO TARGET
+name (DATA) => value_importer => name (CharField)
+oob_ip (DATA) => NO IMPORTER => NO TARGET
+platform (DATA) => relation_importer => platform_id (ForeignKey)
+position (DATA) => integer_importer => position (PositiveSmallIntegerField)
+power_outlet_count (DATA) => NO IMPORTER => NO TARGET
+power_port_count (DATA) => NO IMPORTER => NO TARGET
+primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
+rack (DATA) => relation_importer => rack_id (ForeignKey)
+rear_port_count (DATA) => NO IMPORTER => NO TARGET
 region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
+role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
+serial (DATA) => value_importer => serial (CharField)
+site (DATA) => location_importer => location_id (ForeignKey)
+status (DATA) => status_importer => status_id (StatusField)
+tenant (DATA) => relation_importer => tenant_id (ForeignKey)
+vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * dcim.devicerole => extras.role *******************************************************************
-color (CUSTOM) => value_importer => color (CharField)
+color (DATA) (CUSTOM) => value_importer => color (CharField)
+config_template (DATA) => NO IMPORTER => NO TARGET
 content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.devicetype => dcim.devicetype ***************************************************************
-color (CUSTOM) => NO IMPORTER => NO TARGET
-front_image (CUSTOM) => Disabled with reason: Import does not contain images
+created (DATA) => datetime_importer => created (DateTimeField)
+custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
+description (DATA) => value_importer => description (CharField)
 id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
+last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
+name (DATA) => value_importer => name (CharField)
+slug (DATA) => NO IMPORTER => NO TARGET
+vm_role (DATA) => NO IMPORTER => NO TARGET
+* dcim.devicetype => dcim.devicetype ***************************************************************
+_abs_weight (DATA) => NO IMPORTER => NO TARGET
+airflow (DATA) => NO IMPORTER => NO TARGET
+color (CUSTOM) => NO IMPORTER => NO TARGET
+comments (DATA) => value_importer => comments (TextField)
+console_port_template_count (DATA) => NO IMPORTER => NO TARGET
+console_server_port_template_count (DATA) => NO IMPORTER => NO TARGET
+created (DATA) => datetime_importer => created (DateTimeField)
+custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
+default_platform (DATA) => NO IMPORTER => NO TARGET
+description (DATA) => NO IMPORTER => NO TARGET
+device_bay_template_count (DATA) => NO IMPORTER => NO TARGET
+front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
+front_port_template_count (DATA) => NO IMPORTER => NO TARGET
+id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
+interface_template_count (DATA) => NO IMPORTER => NO TARGET
+inventory_item_template_count (DATA) => NO IMPORTER => NO TARGET
+is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
+last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
 manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
 model (DATA) => value_importer => model (CharField)
-rear_image (CUSTOM) => Disabled with reason: Import does not contain images
+module_bay_template_count (DATA) => NO IMPORTER => NO TARGET
+part_number (DATA) => value_importer => part_number (CharField)
+power_outlet_template_count (DATA) => NO IMPORTER => NO TARGET
+power_port_template_count (DATA) => NO IMPORTER => NO TARGET
+rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
+rear_port_template_count (DATA) => NO IMPORTER => NO TARGET
+slug (DATA) => NO IMPORTER => NO TARGET
+subdevice_role (DATA) => value_importer => subdevice_role (CharField)
+u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
+weight (DATA) => NO IMPORTER => NO TARGET
+weight_unit (DATA) => NO IMPORTER => NO TARGET
 * dcim.frontport => dcim.frontport *****************************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
@@ -233,8 +313,13 @@ parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
 rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
 tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
+created (DATA) => datetime_importer => created (DateTimeField)
+custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
+description (DATA) => value_importer => description (CharField)
 id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
+last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
 name (DATA) => value_importer => name (CharField)
+slug (DATA) => NO IMPORTER => NO TARGET
 * dcim.module => dcim.module ***********************************************************************
     Disable reason: Nautobot content type: `dcim.module` not found
 * dcim.modulebay => dcim.modulebay *****************************************************************
@@ -288,13 +373,29 @@ rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
 status (CUSTOM) => status_importer => status_id (StatusField)
 tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-group (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name (DATA) => NO IMPORTER => NO TARGET
+asns (DATA) => NO IMPORTER => NO TARGET
+comments (DATA) => value_importer => comments (TextField)
+created (DATA) => datetime_importer => created (DateTimeField)
+custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
+description (DATA) => value_importer => description (CharField)
+facility (DATA) => value_importer => facility (CharField)
+group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
+id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
+last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
+latitude (DATA) => value_importer => latitude (DecimalField)
 level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
 lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-region (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
+longitude (DATA) => value_importer => longitude (DecimalField)
+name (DATA) => value_importer => name (CharField)
+physical_address (DATA) => value_importer => physical_address (TextField)
+region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
 rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-status (CUSTOM) => status_importer => status_id (StatusField)
+shipping_address (DATA) => value_importer => shipping_address (TextField)
+slug (DATA) => NO IMPORTER => NO TARGET
+status (DATA) => status_importer => status_id (StatusField)
+tenant (DATA) => relation_importer => tenant_id (ForeignKey)
+time_zone (DATA) => value_importer => time_zone (CharField)
 tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.sitegroup => dcim.locationtype **************************************************************
 content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)

--- a/nautobot_netbox_importer/tests/fixtures/3.6/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6/summary.json
@@ -22,6 +22,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -54,6 +55,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -108,6 +110,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -140,6 +143,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "date_joined": {
                     "name": "date_joined",
@@ -314,6 +318,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 29,
+            "skipped_count": 0,
             "fields": {
                 "cid": {
                     "name": "cid",
@@ -536,6 +541,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 45,
+            "skipped_count": 0,
             "fields": {
                 "cable": {
                     "name": "cable",
@@ -770,6 +776,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -872,6 +879,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "asns": {
                     "name": "asns",
@@ -998,6 +1006,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -1127,6 +1136,7 @@
             "nautobot_flags": "DiffSyncModelFlags.IGNORE",
             "default_reference_uid": null,
             "imported_count": 119,
+            "skipped_count": 0,
             "fields": {
                 "app_label": {
                     "name": "app_label",
@@ -1181,6 +1191,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 108,
+            "skipped_count": 0,
             "fields": {
                 "_abs_length": {
                     "name": "_abs_length",
@@ -1367,6 +1378,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1397,6 +1409,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 216,
+            "skipped_count": 0,
             "fields": {
                 "_device": {
                     "name": "_device",
@@ -1523,6 +1536,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 41,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1733,6 +1747,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -1871,6 +1886,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1901,6 +1917,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -1931,6 +1948,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2309,6 +2327,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2447,6 +2466,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 14,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -2561,6 +2581,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 9,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -2699,6 +2720,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "c40e8fa5-0254-5b8f-97da-19b227497d92",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "_abs_weight": {
                     "name": "_abs_weight",
@@ -2957,6 +2979,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 912,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3179,6 +3202,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 120,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3353,6 +3377,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1586,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -3851,6 +3876,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 300,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -4049,6 +4075,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -4127,6 +4154,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.inventoryitemtemplate": {
@@ -4144,6 +4172,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.location": {
@@ -4161,6 +4190,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4371,6 +4401,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -4497,6 +4528,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "f5136724-0984-5e3b-b073-ea6d83116997",
             "imported_count": 15,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4599,6 +4631,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebay": {
@@ -4616,6 +4649,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.modulebaytemplate": {
@@ -4633,6 +4667,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.moduletype": {
@@ -4650,6 +4685,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "dcim.platform": {
@@ -4667,6 +4703,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -4781,6 +4818,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 48,
+            "skipped_count": 0,
             "fields": {
                 "_path": {
                     "name": "_path",
@@ -5051,6 +5089,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 104,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5273,6 +5312,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5435,6 +5475,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -5573,6 +5614,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 75,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5795,6 +5837,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -5957,6 +6000,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 42,
+            "skipped_count": 0,
             "fields": {
                 "_abs_max_weight": {
                     "name": "_abs_max_weight",
@@ -6335,6 +6379,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 2,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -6473,6 +6518,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -6599,6 +6645,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 630,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6809,6 +6856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 73,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -6971,6 +7019,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 67,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -7157,6 +7206,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 24,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -7463,6 +7513,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 3,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -7649,6 +7700,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -7775,6 +7827,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "django_rq.queue": {
@@ -7792,6 +7845,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.branch": {
@@ -7809,6 +7863,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.cachedvalue": {
@@ -7826,6 +7881,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.configcontext": {
@@ -7843,6 +7899,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -7873,6 +7930,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.customfield": {
@@ -7890,6 +7948,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "choice_set": {
                     "name": "choice_set",
@@ -7897,7 +7956,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choice_set",
                     "from_data": true,
                     "is_custom": true,
                     "default_value": null,
@@ -7909,7 +7968,7 @@
                     "nautobot_internal_type": null,
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
-                    "definition": "_define_choices",
+                    "definition": "define_choices",
                     "from_data": false,
                     "is_custom": true,
                     "default_value": null,
@@ -8160,6 +8219,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "custom_field": {
                     "name": "custom_field",
@@ -8199,6 +8259,24 @@
                 }
             }
         },
+        "extras.customfieldchoiceset": {
+            "content_type": "extras.customfieldchoiceset",
+            "content_type_id": null,
+            "extends_content_type": null,
+            "nautobot_content_type": "extras.customfieldchoiceset",
+            "nautobot_content_type_id": null,
+            "disable_reason": "Nautobot content type: `extras.customfieldchoiceset` not found",
+            "identifiers": null,
+            "disable_related_reference": false,
+            "forward_references": null,
+            "pre_import": "create_choice_set",
+            "flags": "DiffSyncModelFlags.NONE",
+            "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
+            "default_reference_uid": null,
+            "imported_count": 0,
+            "skipped_count": 0,
+            "fields": {}
+        },
         "extras.customlink": {
             "content_type": "extras.customlink",
             "content_type_id": 89,
@@ -8214,6 +8292,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8244,6 +8323,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8274,6 +8354,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8304,6 +8385,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8334,6 +8416,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8359,11 +8442,12 @@
             "identifiers": null,
             "disable_related_reference": true,
             "forward_references": null,
-            "pre_import": null,
+            "pre_import": "skip_disabled_object_types",
             "flags": "DiffSyncModelFlags.NONE",
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8418,6 +8502,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.role": {
@@ -8435,6 +8520,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8477,6 +8563,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.script": {
@@ -8494,6 +8581,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.stagedchange": {
@@ -8511,6 +8599,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "extras.status": {
@@ -8530,6 +8619,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "content_types": {
                     "name": "content_types",
@@ -8584,6 +8674,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 26,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -8698,6 +8789,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 72,
+            "skipped_count": 0,
             "fields": {
                 "content_type": {
                     "name": "content_type",
@@ -8764,6 +8856,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -8794,6 +8887,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -8944,6 +9038,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.fhrpgroup": {
@@ -8961,6 +9056,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9003,6 +9099,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.ipaddress": {
@@ -9020,6 +9117,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "address": {
                     "name": "address",
@@ -9218,6 +9316,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpn": {
@@ -9235,6 +9334,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.l2vpntermination": {
@@ -9252,6 +9352,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.prefix": {
@@ -9269,6 +9370,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 90,
+            "skipped_count": 0,
             "fields": {
                 "_children": {
                     "name": "_children",
@@ -9515,6 +9617,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 8,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -9629,6 +9732,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 5,
+            "skipped_count": 0,
             "fields": {
                 "color": {
                     "name": "color",
@@ -9767,6 +9871,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 12,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -9881,6 +9986,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -9911,6 +10017,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "ipam.vlan": {
@@ -9928,6 +10035,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 63,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10126,6 +10234,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 7,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -10276,6 +10385,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10438,6 +10548,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.secretrole": {
@@ -10455,6 +10566,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.sessionkey": {
@@ -10472,6 +10584,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "secrets.userkey": {
@@ -10489,6 +10602,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "sessions.session": {
@@ -10506,6 +10620,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "session_key": {
                     "name": "session_key",
@@ -10536,6 +10651,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10566,6 +10682,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10596,6 +10713,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10626,6 +10744,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10656,6 +10775,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10686,6 +10806,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10716,6 +10837,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -10746,6 +10868,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactassignment": {
@@ -10763,6 +10886,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactgroup": {
@@ -10780,6 +10904,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.contactrole": {
@@ -10797,6 +10922,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "tenancy.tenant": {
@@ -10814,6 +10940,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 11,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -10940,6 +11067,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 1,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11102,6 +11230,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11132,6 +11261,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "users.objectpermission": {
@@ -11149,6 +11279,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11179,6 +11310,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {
                 "id": {
                     "name": "id",
@@ -11209,6 +11341,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "virtualization.cluster": {
@@ -11226,6 +11359,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 32,
+            "skipped_count": 0,
             "fields": {
                 "comments": {
                     "name": "comments",
@@ -11412,6 +11546,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 4,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11514,6 +11649,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 6,
+            "skipped_count": 0,
             "fields": {
                 "created": {
                     "name": "created",
@@ -11616,6 +11752,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 180,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -11886,6 +12023,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 720,
+            "skipped_count": 0,
             "fields": {
                 "_name": {
                     "name": "_name",
@@ -12120,6 +12258,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslangroup": {
@@ -12137,6 +12276,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         },
         "wireless.wirelesslink": {
@@ -12154,6 +12294,7 @@
             "nautobot_flags": "DiffSyncModelFlags.SKIP_UNMATCHED_DST",
             "default_reference_uid": null,
             "imported_count": 0,
+            "skipped_count": 0,
             "fields": {}
         }
     },

--- a/nautobot_netbox_importer/tests/fixtures/3.6/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.6/summary.txt
@@ -141,6 +141,7 @@ django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type
 extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
 extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
 extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
+extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
 extras.journalentry => extras.note
 extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
 extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
@@ -844,6 +845,8 @@ weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
 custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
 id (CUSTOM) => uid_from_data => id (UUIDField)
 value (CUSTOM) => value_importer => value (CharField)
+* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
+    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
 * extras.customlink => extras.customlink ***********************************************************
 id (CUSTOM) => uid_from_data => id (UUIDField)
 * extras.exporttemplate => extras.exporttemplate ***************************************************

--- a/nautobot_netbox_importer/tests/test_import.py
+++ b/nautobot_netbox_importer/tests/test_import.py
@@ -39,7 +39,7 @@ _EXPECTED_SUMMARY = {
     "3.4": 5870,
     "3.5": 5870,
     "3.6": 5870,
-    "3.6.custom": 31,
+    "3.6.custom": 50,
 }
 
 _EXPECTED_COUNTS = {}
@@ -137,11 +137,18 @@ _EXPECTED_COUNTS["3.6"] = {
 }
 _EXPECTED_COUNTS["3.6.custom"] = {
     "auth.group": 1,
+    "dcim.device": 1,
+    "dcim.devicetype": 1,
     "dcim.interfaceredundancygroup": 1,
-    "extras.customfield": 1,
+    "dcim.location": 1,
+    "dcim.locationtype": 2,
+    "dcim.manufacturer": 1,
+    "extras.customfield": 2,
+    "extras.customfieldchoice": 3,
     "extras.note": 2,
-    "extras.objectchange": 7,
-    "extras.status": 1,
+    "extras.objectchange": 14,
+    "extras.role": 1,
+    "extras.status": 2,
     "tenancy.tenant": 11,
     "tenancy.tenantgroup": 1,
     "users.user": 6,
@@ -169,7 +176,9 @@ _EXPECTED_VALIDATION_ERRORS["3.5"] = {
 _EXPECTED_VALIDATION_ERRORS["3.6"] = {
     **_EXPECTED_VALIDATION_ERRORS["3.5"],
 }
-_EXPECTED_VALIDATION_ERRORS["3.6.custom"] = {}
+_EXPECTED_VALIDATION_ERRORS["3.6.custom"] = {
+    "dcim.location": 1,
+}
 
 
 # Ensure that SECRET_KEY is set to a known value, to generate the same UUIDs


### PR DESCRIPTION
# Closes: NaN

## What's Changed

- Fixed importing `CustomFieldChoices`.
- Updated test summaries.
- Added `pre_import` feature to skip records.
- Fixed fail, when importing non-existent content types for `ObjectChange` model.
- Added more test data.
- Separated custom fields and object change customization to distinct module.
- Avoided double log for save errors.
