### PR TITLE
Fix color field source flapping

### DIFF
--- a/nautobot_netbox_importer/base.py
+++ b/nautobot_netbox_importer/base.py
@@ -5,7 +5,6 @@ from os import PathLike
 from typing import Any
 from typing import List
 from typing import MutableMapping
-from typing import Set
 from typing import Tuple
 from typing import Union
 from uuid import UUID
@@ -20,7 +19,7 @@ RecordData = MutableMapping[FieldName, Any]
 GenericForeignValue = Tuple[ContentTypeStr, Uid]
 Pathable = Union[str, PathLike]
 
-GENERATOR_SETUP_MODULES: Set[str] = set()
+GENERATOR_SETUP_MODULES: List[str] = []
 
 
 def register_generator_setup(module: str) -> None:
@@ -28,4 +27,5 @@ def register_generator_setup(module: str) -> None:
 
     This function must be called before the adapter is used and containing module can't import anything from Nautobot.
     """
-    GENERATOR_SETUP_MODULES.add(module)
+    if module not in GENERATOR_SETUP_MODULES:
+        GENERATOR_SETUP_MODULES.append(module)

--- a/nautobot_netbox_importer/diffsync/models/dcim.py
+++ b/nautobot_netbox_importer/diffsync/models/dcim.py
@@ -82,17 +82,12 @@ def setup(adapter: SourceAdapter) -> None:
         fields={
             "front_image": fields.disable("Import does not contain images"),
             "rear_image": fields.disable("Import does not contain images"),
-            "color": "color",
         },
         default_reference={
             "id": "Unknown",
             "manufacturer": manufacturer.get_default_reference_uid(),
             "model": "Unknown",
         },
-    )
-    adapter.configure_model(
-        "dcim.devicerole",
-        nautobot_content_type="extras.role",
     )
     adapter.configure_model(
         "dcim.device",

--- a/nautobot_netbox_importer/generator/fields.py
+++ b/nautobot_netbox_importer/generator/fields.py
@@ -1,4 +1,5 @@
 """Generic Field Importers definitions for Nautobot Importer."""
+
 from typing import Any
 from typing import Optional
 
@@ -31,16 +32,14 @@ def role(adapter: SourceAdapter, source_content_type: ContentTypeStr) -> SourceF
     Use, when there is a different source role content type, that should be mapped to Nautobot "extras.role".
     Creates a new wrapper for the `source_content_type`, if it does not exist.
     """
-    if source_content_type in adapter.wrappers:
-        role_wrapper = adapter.wrappers[source_content_type]
-    else:
-        role_wrapper = adapter.configure_model(
-            source_content_type,
-            nautobot_content_type="extras.role",
-            fields={
-                "color": "color",
-            },
-        )
+    role_wrapper = adapter.configure_model(
+        source_content_type,
+        nautobot_content_type="extras.role",
+        fields={
+            # Include color to allow setting the default Nautobot value, import fails without it.
+            "color": "color",
+        },
+    )
 
     return relation(role_wrapper, "role")
 

--- a/nautobot_netbox_importer/generator/source.py
+++ b/nautobot_netbox_importer/generator/source.py
@@ -4,6 +4,7 @@
 import datetime
 import json
 from enum import Enum
+from enum import auto
 from typing import Any
 from typing import Callable
 from typing import Dict
@@ -70,6 +71,16 @@ class PreImportResult(Enum):
     USE_RECORD = True
 
 
+class SourceFieldSource(Enum):
+    """Source Field Source."""
+
+    AUTO = auto()
+    CACHE = auto()
+    DATA = auto()
+    CUSTOM = auto()
+    SIBLING = auto()
+
+
 PreImport = Callable[[RecordData, ImporterPass], PreImportResult]
 SourceDataGenerator = Callable[[], Iterable[SourceRecord]]
 SourceFieldImporter = Callable[[RecordData, DiffSyncBaseModel], None]
@@ -111,7 +122,7 @@ class SourceAdapter(BaseAdapter):
         # When multiple source content types are mapped to the single nautobot content type, mapping is set to `None`
         self._content_types_back_mapping: Dict[ContentTypeStr, Optional[ContentTypeStr]] = {}
 
-    # pylint: disable=too-many-arguments,too-many-branches
+    # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
     def configure_model(
         self,
         content_type: ContentTypeStr,
@@ -164,8 +175,8 @@ class SourceAdapter(BaseAdapter):
 
         if identifiers:
             wrapper.set_identifiers(identifiers)
-        if fields:
-            wrapper.set_fields(**fields)
+        for field_name, definition in (fields or {}).items():
+            wrapper.add_field(field_name, SourceFieldSource.CUSTOM).set_definition(definition)
         if default_reference:
             wrapper.set_default_reference(default_reference)
         if flags is not None:
@@ -278,7 +289,7 @@ class SourceAdapter(BaseAdapter):
                 continue
 
             for field_name in data.keys():
-                wrapper.add_field(field_name, field_name, from_data=True)
+                wrapper.add_field(field_name, SourceFieldSource.DATA)
 
         # Create importers, wrappers structure is updated as needed
         while True:
@@ -389,7 +400,7 @@ class SourceModelWrapper:
             self.adapter.logger.debug("Created disabled %s", self)
             return
 
-        pk_field = self.add_field(nautobot_wrapper.pk_field.name, nautobot_wrapper.pk_field.name)
+        pk_field = self.add_field(nautobot_wrapper.pk_field.name, SourceFieldSource.AUTO)
         pk_field.set_nautobot_field(pk_field.name)
         pk_field.processed = True
 
@@ -436,36 +447,24 @@ class SourceModelWrapper:
 
     def disable_field(self, field_name: FieldName, reason: str) -> "SourceField":
         """Disable field importing."""
-        field = self.add_field(field_name, None)
+        field = self.add_field(field_name, SourceFieldSource.CUSTOM)
         field.disable(reason)
         return field
-
-    def set_fields(self, *field_names: FieldName, **fields: SourceFieldDefinition) -> None:
-        """Set fields definitions."""
-        for field_name in field_names:
-            self.add_field(field_name, field_name)
-        for field_name, definition in fields.items():
-            self.add_field(field_name, definition)
 
     def format_field_name(self, name: FieldName) -> str:
         """Format a field name for logging."""
         return f"{self.content_type}->{name}"
 
-    def add_field(self, name: FieldName, definition: SourceFieldDefinition, from_data: bool = False) -> "SourceField":
+    def add_field(self, name: FieldName, source: SourceFieldSource) -> "SourceField":
         """Add a field definition for a source field."""
         if self.importers is not None:
             raise ValueError(f"Can't add field {self.format_field_name(name)}, model's importers already created.")
 
-        if name in self.fields:
-            field = self.fields[name]
-            if from_data:
-                # Do not update the definition from data when already defined
-                field.from_data = True
-            else:
-                field.reset_definition(definition)
-        else:
-            field = SourceField(self, name, definition, from_data)
+        if name not in self.fields:
+            return SourceField(self, name, source)
 
+        field = self.fields[name]
+        field.sources.add(source)
         return field
 
     def create_importers(self) -> None:
@@ -475,8 +474,8 @@ class SourceModelWrapper:
 
         if not self.extends_wrapper:
             for field_name in AUTO_ADD_FIELDS:
-                if field_name not in self.fields and hasattr(self.nautobot.model, field_name):
-                    self.add_field(field_name, field_name)
+                if hasattr(self.nautobot.model, field_name):
+                    self.add_field(field_name, SourceFieldSource.AUTO)
 
         while True:
             fields = [field for field in self.fields.values() if not field.processed]
@@ -616,7 +615,7 @@ class SourceModelWrapper:
 
         if self.importers is None:
             for field_name in data.keys():
-                self.add_field(field_name, field_name, from_data=True)
+                self.add_field(field_name, SourceFieldSource.CACHE)
 
         self._cached_data[uid] = data
 
@@ -678,21 +677,13 @@ class SourceModelWrapper:
 class SourceField:
     """Source Field."""
 
-    def __init__(
-        self,
-        wrapper: SourceModelWrapper,
-        name: FieldName,
-        definition: SourceFieldDefinition,
-        from_data=False,
-    ):
+    def __init__(self, wrapper: SourceModelWrapper, name: FieldName, source: SourceFieldSource):
         """Initialize the SourceField."""
         self.wrapper = wrapper
         wrapper.fields[name] = self
-
         self.name = name
-        self.from_data = from_data
-        self.is_custom = not from_data
-        self.definition = definition
+        self.definition: SourceFieldDefinition = name
+        self.sources = set((source,))
         self.processed = False
         self._nautobot: Optional[NautobotField] = None
         self.importer: Optional[SourceFieldImporter] = None
@@ -719,8 +710,7 @@ class SourceField:
             nautobot_can_import=self._nautobot and self._nautobot.can_import,
             importer=self.importer and self.importer.__name__,
             definition=serialize_to_summary(self.definition),
-            from_data=self.from_data,
-            is_custom=self.is_custom,
+            sources=sorted(source.name for source in self.sources),
             default_value=serialize_to_summary(self.default_value),
             disable_reason=self.disable_reason,
         )
@@ -738,10 +728,7 @@ class SourceField:
             raise RuntimeError(f"Call `handle sibling` after setting importer for {self}")
 
         if isinstance(sibling, FieldName):
-            if sibling in self.wrapper.fields:
-                sibling = self.wrapper.fields[sibling]
-            else:
-                sibling = self.wrapper.add_field(sibling, nautobot_name or self.nautobot.name)
+            sibling = self.wrapper.add_field(sibling, SourceFieldSource.SIBLING)
 
         sibling.set_nautobot_field(nautobot_name or self.nautobot.name)
         sibling.importer = self.importer
@@ -752,16 +739,17 @@ class SourceField:
 
         return sibling
 
-    def reset_definition(self, definition: SourceFieldDefinition) -> None:
-        """Set a custom definition for the field."""
+    def set_definition(self, definition: SourceFieldDefinition) -> None:
+        """Customize field definition."""
         if self.processed:
-            raise RuntimeError(f"Field already processed. {self.wrapper.format_field_name(self.name)}")
-        if self.is_custom:
-            raise RuntimeError(
-                f"Can't reset custom definition for a non-custom field {self.wrapper.format_field_name(self.name)}"
-            )
-        self.is_custom = True
-        self.definition = definition
+            raise RuntimeError(f"Field already processed. {self}")
+
+        if self.definition != definition:
+            if self.definition != self.name:
+                self.wrapper.adapter.logger.warning(
+                    "Overriding custom field definition %s %s -> %s", self, self.definition, definition
+                )
+            self.definition = definition
 
     def create_importer(self) -> None:
         """Create importer for the field."""

--- a/nautobot_netbox_importer/tests/fixtures/3.0/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.0/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -107,8 +110,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -140,8 +144,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -152,8 +157,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +170,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +183,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +196,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +209,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -212,8 +222,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -224,8 +235,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +248,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -248,8 +262,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -260,8 +275,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -284,8 +303,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -315,8 +335,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -327,8 +348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +361,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +374,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +387,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +400,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +413,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +440,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -423,8 +453,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -435,8 +466,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -447,8 +480,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -459,8 +493,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -471,8 +507,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +521,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -514,8 +554,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -526,8 +567,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -538,8 +580,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -550,8 +593,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +606,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +619,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +632,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -610,8 +659,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -622,8 +672,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -634,8 +685,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -646,8 +698,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +711,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -669,9 +723,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -682,8 +737,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -694,8 +751,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -706,8 +764,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +777,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -749,8 +809,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -761,8 +822,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -773,8 +835,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -785,8 +848,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -809,8 +875,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -821,8 +888,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -852,8 +920,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -864,8 +933,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "admin_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -876,8 +946,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "asn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -888,8 +959,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +972,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +985,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +998,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -948,8 +1025,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -960,8 +1038,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "noc_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -972,8 +1051,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "portal_url",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -984,8 +1064,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1015,8 +1096,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1027,8 +1109,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1039,8 +1122,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1135,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1148,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1162,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1087,8 +1175,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1188,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1133,8 +1223,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1145,8 +1237,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1157,8 +1250,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1188,8 +1282,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1200,8 +1295,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_termination_a_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1212,8 +1308,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_termination_b_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1224,8 +1321,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1236,8 +1334,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1347,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1360,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1387,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1296,8 +1400,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1308,8 +1413,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1320,8 +1426,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1332,8 +1440,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1344,8 +1453,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1356,8 +1466,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1368,8 +1479,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1380,8 +1492,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1411,8 +1524,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1442,8 +1556,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1473,8 +1588,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1485,8 +1601,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1497,8 +1614,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1509,8 +1627,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1521,8 +1640,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1533,8 +1653,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1545,8 +1666,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1557,8 +1679,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1692,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1705,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1719,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1732,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1617,8 +1745,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1758,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1641,8 +1771,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1784,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1684,8 +1816,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1696,8 +1829,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1708,8 +1842,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1720,8 +1855,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1732,8 +1868,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1744,8 +1882,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1756,8 +1895,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1768,8 +1908,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1921,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1811,8 +1953,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1842,8 +1985,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1873,8 +2017,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1885,8 +2030,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1897,8 +2043,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1909,8 +2056,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1921,8 +2069,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1933,8 +2082,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1945,8 +2095,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1957,8 +2109,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1969,8 +2122,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2135,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2149,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2005,8 +2162,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2175,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2189,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2041,8 +2202,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2053,8 +2215,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2228,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2077,8 +2241,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2089,8 +2254,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2100,9 +2266,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2113,8 +2280,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2293,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2137,8 +2306,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2320,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2161,8 +2334,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2347,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2185,8 +2360,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2197,8 +2373,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2228,8 +2405,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2240,8 +2418,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2252,8 +2431,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2264,8 +2444,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2276,8 +2457,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2288,8 +2470,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2300,8 +2484,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2312,8 +2497,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2324,8 +2510,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2336,8 +2523,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2367,8 +2555,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2398,8 +2587,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2410,8 +2601,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2422,8 +2614,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2434,8 +2627,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2446,8 +2640,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2458,8 +2653,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2470,8 +2667,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2482,8 +2680,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2494,8 +2693,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2506,8 +2706,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2530,18 +2731,6 @@
             "imported_count": 13,
             "skipped_count": 0,
             "fields": {
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
                 "comments": {
                     "name": "comments",
                     "nautobot_name": "comments",
@@ -2549,8 +2738,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2561,8 +2751,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2573,8 +2764,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2585,8 +2777,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2597,8 +2791,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2609,8 +2806,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2621,8 +2819,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2633,8 +2832,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2645,8 +2846,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2657,8 +2860,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2669,8 +2873,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2681,8 +2887,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2693,8 +2900,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2705,8 +2913,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 }
@@ -2736,8 +2945,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2748,8 +2958,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2760,8 +2971,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2772,8 +2984,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2784,8 +2997,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2796,8 +3010,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2808,8 +3023,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2820,8 +3036,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2832,8 +3049,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2844,8 +3062,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2856,8 +3076,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2868,8 +3089,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2880,8 +3102,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2892,8 +3115,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2904,8 +3128,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2916,8 +3141,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -2928,8 +3154,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2959,8 +3186,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2971,8 +3199,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2983,8 +3212,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2995,8 +3225,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3007,8 +3238,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3019,8 +3251,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3031,8 +3265,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3043,8 +3278,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3055,8 +3291,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3067,8 +3304,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3079,8 +3318,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3091,8 +3331,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3122,8 +3363,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3134,8 +3376,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3146,8 +3389,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3158,8 +3402,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3170,8 +3415,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3182,8 +3428,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3194,8 +3441,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3206,8 +3454,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3218,8 +3467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3230,8 +3480,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3242,8 +3493,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3254,8 +3507,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3266,8 +3520,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3278,8 +3533,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3290,8 +3546,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3302,8 +3559,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3314,8 +3572,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3326,8 +3585,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3338,8 +3598,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3350,8 +3611,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3362,8 +3624,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3374,8 +3638,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3386,8 +3651,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3664,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3677,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3441,8 +3709,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3453,8 +3722,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3465,8 +3735,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3477,8 +3748,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3489,8 +3761,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3501,8 +3775,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3513,8 +3788,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3525,8 +3801,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3537,8 +3814,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3549,8 +3827,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3580,8 +3859,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3592,8 +3872,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3604,8 +3885,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3616,8 +3898,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3628,8 +3911,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3659,8 +3943,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3671,8 +3956,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3683,8 +3969,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3695,8 +3982,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3707,8 +3996,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3719,8 +4009,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3731,8 +4023,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3743,8 +4037,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3755,8 +4050,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3767,8 +4063,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3779,8 +4077,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3791,8 +4091,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3803,8 +4105,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3815,8 +4118,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3827,8 +4131,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3858,8 +4164,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3870,8 +4177,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3882,8 +4191,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3894,8 +4204,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3906,8 +4217,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3918,8 +4230,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3930,8 +4243,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3942,8 +4256,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3954,8 +4269,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3985,8 +4301,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3997,8 +4314,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4009,8 +4327,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4021,8 +4340,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4033,8 +4355,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4045,8 +4368,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4057,8 +4382,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4088,8 +4414,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4100,8 +4427,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4112,8 +4440,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4124,8 +4453,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4136,8 +4467,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4148,8 +4480,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4160,8 +4493,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4172,8 +4506,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "napalm_args",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4184,8 +4519,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "napalm_driver",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4196,8 +4532,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4227,8 +4564,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4239,8 +4577,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4251,8 +4590,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4263,8 +4603,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4275,8 +4616,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4287,8 +4629,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4299,8 +4642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4311,8 +4655,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4323,8 +4668,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4335,8 +4681,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4347,8 +4695,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4359,8 +4708,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4371,8 +4721,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -4383,8 +4734,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4395,8 +4747,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -4407,8 +4760,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4419,8 +4773,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4431,8 +4786,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4443,8 +4800,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -4455,8 +4813,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -4467,8 +4826,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -4498,8 +4858,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4510,8 +4871,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4522,8 +4884,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4534,8 +4897,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4546,8 +4910,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4558,8 +4923,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4570,8 +4936,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4582,8 +4949,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4594,8 +4962,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4606,8 +4975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4618,8 +4988,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4630,8 +5002,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4642,8 +5015,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4654,8 +5028,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4666,8 +5041,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4678,8 +5054,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4690,8 +5067,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4721,8 +5099,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4733,8 +5112,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4745,8 +5125,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4757,8 +5138,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -4769,8 +5151,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4781,8 +5164,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4793,8 +5178,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4805,8 +5191,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4817,8 +5204,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4829,8 +5217,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4841,8 +5231,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4872,8 +5263,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4884,8 +5276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4896,8 +5289,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4908,8 +5303,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4920,8 +5316,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4932,8 +5330,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4943,9 +5342,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4956,8 +5356,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4987,8 +5389,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4999,8 +5402,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5011,8 +5415,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5023,8 +5428,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5035,8 +5441,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5047,8 +5454,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5059,8 +5467,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5071,8 +5480,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5083,8 +5493,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5095,8 +5506,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5107,8 +5519,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5119,8 +5533,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5131,8 +5546,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5143,8 +5559,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5155,8 +5572,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5167,8 +5585,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5179,8 +5598,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5210,8 +5630,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5222,8 +5643,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5234,8 +5656,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5246,8 +5669,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5258,8 +5682,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5270,8 +5695,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5282,8 +5709,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5294,8 +5722,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5306,8 +5735,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5318,8 +5748,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5330,8 +5761,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5361,8 +5793,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5373,8 +5806,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5385,8 +5819,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5397,8 +5832,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5409,8 +5845,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5421,8 +5858,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -5433,8 +5871,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5445,8 +5884,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5457,8 +5898,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5469,8 +5911,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5481,8 +5925,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5493,8 +5938,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5505,8 +5951,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5517,8 +5964,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5528,9 +5976,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5541,8 +5990,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5553,8 +6004,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5565,8 +6017,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5577,8 +6031,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -5589,8 +6045,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5601,8 +6058,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5613,8 +6071,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -5625,8 +6084,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -5656,8 +6116,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5668,8 +6129,9 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5699,8 +6161,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -5711,8 +6175,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5723,8 +6188,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5735,8 +6201,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5747,8 +6214,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5759,8 +6227,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5771,8 +6241,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5783,8 +6254,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5795,8 +6267,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5826,8 +6299,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5838,8 +6312,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_cable_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5850,8 +6325,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5862,8 +6338,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5874,8 +6351,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5886,8 +6364,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5898,8 +6377,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5910,8 +6390,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5922,8 +6403,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5934,8 +6416,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5946,8 +6430,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5958,8 +6443,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5970,8 +6456,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5982,8 +6469,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5994,8 +6482,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6006,8 +6495,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6037,8 +6527,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6049,8 +6540,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6061,8 +6553,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6073,8 +6566,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6085,8 +6579,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6097,8 +6592,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6109,8 +6606,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6121,8 +6619,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6133,8 +6632,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6145,8 +6645,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6157,8 +6658,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6188,8 +6690,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6200,8 +6703,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6212,8 +6716,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6224,8 +6729,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6236,8 +6743,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6248,8 +6756,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6260,8 +6770,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6272,8 +6784,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6284,8 +6797,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6296,8 +6810,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6308,8 +6823,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6320,8 +6837,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6332,8 +6850,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6344,8 +6863,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -6375,8 +6896,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6387,8 +6909,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "asn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6399,8 +6922,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6411,8 +6935,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "contact_email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6423,8 +6948,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "contact_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6435,8 +6961,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "contact_phone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6447,8 +6974,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6459,8 +6987,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6471,8 +7000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6483,8 +7013,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6495,8 +7026,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6507,8 +7040,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6519,8 +7054,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6531,8 +7067,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6543,8 +7080,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6555,8 +7093,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6567,8 +7106,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6579,8 +7119,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6591,8 +7132,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6603,8 +7145,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6615,8 +7159,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6627,8 +7172,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6639,8 +7185,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6651,8 +7198,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6663,8 +7212,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6675,8 +7225,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6687,8 +7238,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -6718,8 +7270,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6730,8 +7283,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6742,8 +7296,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6754,8 +7309,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6766,8 +7322,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -6778,8 +7335,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6790,8 +7348,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6802,8 +7361,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -6833,8 +7393,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6864,8 +7425,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6895,8 +7457,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6907,8 +7470,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6919,8 +7484,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6931,8 +7498,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6943,8 +7511,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6955,8 +7524,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6967,8 +7537,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -6979,8 +7550,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6991,8 +7564,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7003,8 +7577,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7015,8 +7590,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7027,8 +7604,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7039,8 +7617,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -7051,8 +7630,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7063,8 +7643,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7075,8 +7656,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7087,8 +7669,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -7118,8 +7701,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7130,8 +7714,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7142,8 +7727,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7191,8 +7777,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7222,8 +7809,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7253,8 +7841,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7284,8 +7873,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7315,8 +7905,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7346,8 +7937,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7358,8 +7950,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7370,8 +7963,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7419,8 +8013,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7431,8 +8026,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7482,8 +8078,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7494,8 +8091,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7506,8 +8104,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7537,8 +8136,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7549,8 +8149,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7580,8 +8181,9 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7592,8 +8194,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7604,8 +8207,9 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7616,8 +8220,9 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7647,8 +8252,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7678,8 +8284,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7690,8 +8297,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7702,8 +8310,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7714,8 +8323,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7726,8 +8336,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7738,8 +8350,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7750,8 +8363,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7762,8 +8376,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7774,8 +8389,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7786,8 +8402,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7817,8 +8434,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7829,8 +8447,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -7860,8 +8479,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7872,8 +8492,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7884,8 +8505,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -7933,8 +8555,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7945,8 +8568,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7957,8 +8581,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7969,8 +8594,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7981,8 +8607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7993,8 +8620,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8005,8 +8634,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8017,8 +8647,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8029,8 +8660,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8041,8 +8673,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8053,8 +8686,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8064,9 +8698,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8077,8 +8712,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8089,8 +8726,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8101,8 +8740,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8113,8 +8754,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8125,8 +8767,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8137,8 +8780,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8168,8 +8812,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8180,8 +8825,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8192,8 +8838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8204,8 +8851,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8216,8 +8865,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -8228,8 +8878,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8240,8 +8891,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8252,8 +8904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8283,8 +8936,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8295,8 +8949,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8307,8 +8962,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8319,8 +8975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8331,8 +8988,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8343,8 +9001,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8355,8 +9015,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8367,8 +9028,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8379,8 +9041,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8391,8 +9054,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8422,8 +9086,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8453,8 +9118,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8484,8 +9150,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8496,8 +9163,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8508,8 +9176,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8520,8 +9189,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8532,8 +9203,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8544,8 +9217,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8556,8 +9230,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8568,8 +9243,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8579,9 +9255,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8592,8 +9269,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8604,8 +9283,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8616,8 +9297,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8628,8 +9311,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8640,8 +9324,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8671,8 +9356,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8683,8 +9369,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8695,8 +9382,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8707,8 +9395,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8719,8 +9409,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8731,8 +9422,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8743,8 +9435,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8755,8 +9448,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8767,8 +9461,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8798,8 +9493,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8901,8 +9597,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8932,8 +9629,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8963,8 +9661,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8994,8 +9693,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9006,8 +9706,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9018,8 +9719,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9030,8 +9732,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9042,8 +9745,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9054,8 +9759,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9066,8 +9773,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9078,8 +9786,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9090,8 +9799,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9121,8 +9831,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9133,8 +9844,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9145,8 +9857,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9157,8 +9870,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9169,8 +9884,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9181,8 +9897,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -9193,8 +9911,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -9205,8 +9925,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9217,8 +9938,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9229,8 +9951,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -9241,8 +9965,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9253,8 +9978,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -9284,8 +10011,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9333,8 +10061,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9364,8 +10093,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9413,8 +10143,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9425,8 +10156,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9437,8 +10169,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9449,8 +10182,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9461,8 +10196,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9473,8 +10210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9485,8 +10223,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9497,8 +10236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9508,9 +10248,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9521,8 +10262,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9533,8 +10276,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9545,8 +10289,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9576,8 +10322,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9588,8 +10335,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9600,8 +10348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9612,8 +10361,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9624,8 +10375,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9636,8 +10388,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9648,8 +10401,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9679,8 +10433,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9691,8 +10446,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9703,8 +10459,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9715,8 +10472,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9727,8 +10486,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9739,8 +10499,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9751,8 +10512,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9782,8 +10544,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9794,8 +10557,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9806,8 +10570,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9818,8 +10583,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9830,8 +10596,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9842,8 +10609,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9854,8 +10622,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9866,8 +10636,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9878,8 +10649,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9890,8 +10662,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9902,8 +10675,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9914,8 +10688,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9926,8 +10701,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9938,8 +10714,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9950,8 +10727,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9962,8 +10741,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9974,8 +10755,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9986,8 +10768,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10017,8 +10800,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10029,8 +10813,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10041,8 +10826,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10053,8 +10839,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10065,8 +10852,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -10077,8 +10865,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10089,8 +10879,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10101,8 +10892,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10113,8 +10905,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10125,8 +10918,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10137,8 +10931,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10149,8 +10944,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10161,8 +10958,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -10173,8 +10971,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10185,8 +10984,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10197,8 +10997,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.0/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.0/summary.txt
@@ -109,845 +109,663 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
-dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
-dcim.sitegroup => dcim.locationtype
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
 ipam.aggregate => ipam.prefix
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
 ipam.role => extras.role
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
-dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
-dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
-* auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-permissions (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-account (DATA) => value_importer => account (CharField)
-admin_contact (DATA) => value_importer => admin_contact (TextField)
-asn (DATA) => integer_importer => asn (BigIntegerField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-noc_contact (DATA) => value_importer => noc_contact (TextField)
-portal_url (DATA) => value_importer => portal_url (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+account => value_importer => account (CharField)
+admin_contact => value_importer => admin_contact (TextField)
+asn => integer_importer => asn (BigIntegerField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+noc_contact => value_importer => noc_contact (TextField)
+portal_url => value_importer => portal_url (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-_termination_a_device (DATA) => NO IMPORTER => NO TARGET
-_termination_b_device (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
-* dcim.cabletermination => dcim.cable **************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_abs_length => NO IMPORTER => NO TARGET
+_termination_a_device => NO IMPORTER => NO TARGET
+_termination_b_device => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-device_role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+device_role => relation_importer => role_id (RoleField)
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-* dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
 * dcim.frontport => dcim.frontport *****************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-napalm_args (DATA) => json_importer => napalm_args (JSONField)
-napalm_driver (DATA) => value_importer => napalm_driver (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+napalm_args => json_importer => napalm_args (JSONField)
+napalm_driver => value_importer => napalm_driver (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
-* dcim.rackreservation => dcim.rackreservation *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-units (CUSTOM) => units_importer => units (JSONField)
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_cable_peer_id (DATA) => NO IMPORTER => NO TARGET
-_cable_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_cable_peer_id => NO IMPORTER => NO TARGET
+_cable_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asn (DATA) => integer_importer => asn (BigIntegerField)
-comments (DATA) => value_importer => comments (TextField)
-contact_email (DATA) => value_importer => contact_email (CharField)
-contact_name (DATA) => value_importer => contact_name (CharField)
-contact_phone (DATA) => value_importer => contact_phone (CharField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.virtualchassis => dcim.virtualchassis *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+asn => integer_importer => asn (BigIntegerField)
+comments => value_importer => comments (TextField)
+contact_email => value_importer => contact_email (CharField)
+contact_name => value_importer => contact_name (CharField)
+contact_phone => value_importer => contact_phone (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (CUSTOM) => choices_importer => Custom Target
-choices (DATA) (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-required (DATA) => value_importer => required (BooleanField)
-type (DATA) => value_importer => type (CharField)
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
-* extras.tag => extras.tag *************************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (CUSTOM) => tagged_object_importer => content_type_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (CUSTOM) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+choices => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+required => value_importer => required (BooleanField)
+type => value_importer => type (CharField)
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.aggregate => ipam.prefix ********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.ipaddress => ipam.ipaddress *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* ipam.routetarget => ipam.routetarget *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.vlan => ipam.vlan ***************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
-* ipam.vrf => ipam.vrf *****************************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.1/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.1/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -88,8 +91,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -119,8 +124,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -152,8 +158,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +171,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +197,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -212,8 +223,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -224,8 +236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -248,8 +262,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -260,8 +276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -284,8 +303,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -296,8 +317,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -327,8 +349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +362,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +375,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +388,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +441,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -423,8 +454,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -435,8 +467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,8 +480,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -459,8 +494,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -471,8 +507,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +521,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -495,8 +535,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -526,8 +568,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -538,8 +581,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -550,8 +594,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +607,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +620,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +633,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -610,8 +660,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -622,8 +673,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -634,8 +686,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -646,8 +699,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +712,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -670,8 +725,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -681,9 +737,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -694,8 +751,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -706,8 +765,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +778,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -730,8 +791,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -761,8 +823,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -773,8 +836,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -785,8 +849,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -809,8 +876,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -821,8 +889,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -833,8 +902,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -864,8 +934,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -876,8 +947,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "admin_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -888,8 +960,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "asn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +973,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +986,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +999,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -948,8 +1026,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -960,8 +1039,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -972,8 +1052,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "noc_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -984,8 +1065,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "portal_url",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -996,8 +1078,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1027,8 +1110,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1039,8 +1123,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1149,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1162,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1087,8 +1176,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1099,8 +1189,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1111,8 +1202,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1145,8 +1237,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1157,8 +1251,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1169,8 +1264,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1200,8 +1296,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1212,8 +1309,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_termination_a_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1224,8 +1322,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_termination_b_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1236,8 +1335,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1348,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1361,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1388,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1296,8 +1401,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1308,8 +1414,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1320,8 +1427,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1332,8 +1440,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1344,8 +1454,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1356,8 +1467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1368,8 +1480,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1380,8 +1493,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1392,8 +1506,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1404,8 +1519,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1435,8 +1551,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1466,8 +1583,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1497,8 +1615,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1509,8 +1628,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1521,8 +1641,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1533,8 +1654,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1545,8 +1667,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1557,8 +1680,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1693,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1706,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1719,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1732,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1617,8 +1746,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1759,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1641,8 +1772,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1785,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1665,8 +1798,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1677,8 +1811,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1708,8 +1843,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1720,8 +1856,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1732,8 +1869,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1744,8 +1882,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1756,8 +1895,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1768,8 +1909,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1922,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1792,8 +1935,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1804,8 +1948,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1835,8 +1980,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1866,8 +2012,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1897,8 +2044,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1909,8 +2057,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1921,8 +2070,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1933,8 +2083,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1945,8 +2096,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1957,8 +2109,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1969,8 +2122,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2135,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2149,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2005,8 +2162,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2175,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2189,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2041,8 +2202,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2053,8 +2215,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2229,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2077,8 +2242,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2089,8 +2255,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2101,8 +2268,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2113,8 +2281,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2294,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2136,9 +2306,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2320,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2161,8 +2333,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2346,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2185,8 +2360,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2197,8 +2374,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2209,8 +2387,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2221,8 +2400,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2233,8 +2413,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2264,8 +2445,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2276,8 +2458,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2288,8 +2471,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2300,8 +2484,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2312,8 +2497,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2324,8 +2510,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2336,8 +2524,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2348,8 +2537,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2360,8 +2550,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2372,8 +2563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2403,8 +2595,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2415,8 +2608,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2427,8 +2621,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2439,8 +2634,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2451,8 +2647,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2463,8 +2661,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2475,8 +2674,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2487,8 +2687,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2518,8 +2719,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2530,8 +2733,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2542,8 +2746,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2554,8 +2759,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2566,8 +2772,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2578,8 +2785,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2590,8 +2799,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2602,8 +2812,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2614,8 +2825,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2626,8 +2838,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2657,20 +2870,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2681,8 +2883,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2693,8 +2896,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2705,8 +2909,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2717,8 +2922,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2729,8 +2936,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2741,8 +2951,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2753,8 +2964,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2765,8 +2977,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2777,8 +2991,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2789,8 +3005,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2801,8 +3018,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2813,8 +3032,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2825,8 +3045,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2837,8 +3058,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 }
@@ -2868,8 +3090,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2880,8 +3103,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2892,8 +3116,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2904,8 +3129,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2916,8 +3142,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2928,8 +3155,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2940,8 +3168,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2952,8 +3181,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2964,8 +3194,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2976,8 +3207,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2988,8 +3221,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3000,8 +3234,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3012,8 +3247,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3024,8 +3260,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3036,8 +3273,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3048,8 +3286,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3060,8 +3299,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3091,8 +3331,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3103,8 +3344,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3115,8 +3357,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3127,8 +3370,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3139,8 +3383,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3151,8 +3396,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3163,8 +3410,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3175,8 +3423,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3187,8 +3436,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3199,8 +3449,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3211,8 +3463,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3223,8 +3476,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3254,8 +3508,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3266,8 +3521,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3278,8 +3534,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3290,8 +3547,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3302,8 +3560,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3314,8 +3573,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3326,8 +3586,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3338,8 +3599,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3350,8 +3612,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3362,8 +3625,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3374,8 +3638,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3386,8 +3651,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3665,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3678,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3422,8 +3691,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3434,8 +3704,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3446,8 +3717,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3458,8 +3730,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3470,8 +3743,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3482,8 +3756,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3494,8 +3769,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3506,8 +3782,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3518,8 +3796,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3530,8 +3809,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_frequency",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3542,8 +3822,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3554,8 +3835,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3566,8 +3848,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3578,8 +3861,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3590,8 +3874,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tx_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3602,8 +3887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3614,8 +3900,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3626,8 +3913,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_lans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3638,8 +3926,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_link",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3650,8 +3939,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wwn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3681,8 +3971,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3693,8 +3984,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3705,8 +3997,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3717,8 +4010,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3729,8 +4023,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3741,8 +4037,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3753,8 +4050,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3765,8 +4063,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3777,8 +4076,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3789,8 +4089,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3820,8 +4121,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3832,8 +4134,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3844,8 +4147,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3856,8 +4160,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3868,8 +4173,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3899,8 +4205,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3911,8 +4218,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3923,8 +4231,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3935,8 +4244,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3947,8 +4258,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3959,8 +4271,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3971,8 +4285,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3983,8 +4299,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3995,8 +4312,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4007,8 +4325,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4019,8 +4339,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4031,8 +4353,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4043,8 +4367,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4055,8 +4380,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4067,8 +4393,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4079,8 +4406,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4110,8 +4439,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4122,8 +4452,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4134,8 +4466,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4146,8 +4479,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4158,8 +4492,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4170,8 +4505,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4182,8 +4518,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4194,8 +4531,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4206,8 +4544,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4237,8 +4576,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4249,8 +4589,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4261,8 +4602,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4273,8 +4615,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4285,8 +4630,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4297,8 +4643,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4309,8 +4657,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4340,8 +4689,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4352,8 +4702,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4364,8 +4715,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4376,8 +4728,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4388,8 +4742,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4400,8 +4755,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4412,8 +4768,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4424,8 +4781,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "napalm_args",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4436,8 +4794,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "napalm_driver",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4448,8 +4807,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4479,8 +4839,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4491,8 +4852,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4503,8 +4865,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4515,8 +4878,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4527,8 +4891,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4539,8 +4904,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4551,8 +4917,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4563,8 +4930,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4575,8 +4943,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4587,8 +4956,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4599,8 +4970,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4611,8 +4983,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4623,8 +4996,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -4635,8 +5009,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4647,8 +5022,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -4659,8 +5035,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4671,8 +5048,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4683,8 +5061,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4695,8 +5075,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -4707,8 +5088,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -4719,8 +5101,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -4750,8 +5133,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4762,8 +5146,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4774,8 +5159,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4786,8 +5172,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4798,8 +5185,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4810,8 +5198,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4822,8 +5211,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4834,8 +5224,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4846,8 +5237,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4858,8 +5250,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4870,8 +5263,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4882,8 +5277,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4894,8 +5290,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4906,8 +5303,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4918,8 +5316,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4930,8 +5329,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4942,8 +5342,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4973,8 +5374,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4985,8 +5387,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4997,8 +5400,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5009,8 +5413,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5021,8 +5426,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5033,8 +5439,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5045,8 +5453,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5057,8 +5466,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5069,8 +5479,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5081,8 +5492,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5093,8 +5506,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5124,8 +5538,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5136,8 +5551,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5148,8 +5564,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5160,8 +5578,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5172,8 +5591,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5184,8 +5605,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5195,9 +5617,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5208,8 +5631,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5239,8 +5664,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5251,8 +5677,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5263,8 +5690,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5275,8 +5703,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5287,8 +5716,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5299,8 +5729,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5311,8 +5742,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5323,8 +5755,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5335,8 +5768,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5347,8 +5781,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5359,8 +5794,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5371,8 +5808,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5383,8 +5821,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5395,8 +5834,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5407,8 +5847,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5419,8 +5860,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5431,8 +5873,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5462,8 +5905,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5474,8 +5918,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5486,8 +5931,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5498,8 +5944,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5510,8 +5957,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5522,8 +5970,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5534,8 +5984,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5546,8 +5997,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5558,8 +6010,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5570,8 +6023,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5582,8 +6036,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5613,8 +6068,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5625,8 +6081,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5637,8 +6094,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5649,8 +6107,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5661,8 +6120,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5673,8 +6133,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -5685,8 +6146,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5697,8 +6159,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5709,8 +6173,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5721,8 +6186,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5733,8 +6200,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5745,8 +6213,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5757,8 +6226,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5769,8 +6239,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5780,9 +6251,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5793,8 +6265,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5805,8 +6279,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5817,8 +6292,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5829,8 +6306,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -5841,8 +6320,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5853,8 +6333,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5865,8 +6346,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -5877,8 +6359,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -5908,8 +6391,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5920,8 +6404,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5932,8 +6417,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5944,8 +6430,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5956,8 +6444,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5968,8 +6457,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5980,8 +6470,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5992,8 +6483,10 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6004,8 +6497,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6035,8 +6529,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -6047,8 +6543,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6059,8 +6556,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6071,8 +6569,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6083,8 +6582,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6095,8 +6595,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6107,8 +6609,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6119,8 +6622,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6131,8 +6635,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6162,8 +6667,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6174,8 +6680,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6186,8 +6693,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6198,8 +6706,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6210,8 +6719,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6222,8 +6732,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6234,8 +6745,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6246,8 +6758,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6258,8 +6771,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6270,8 +6784,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6282,8 +6798,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6294,8 +6811,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6306,8 +6824,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6318,8 +6837,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6330,8 +6850,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6342,8 +6863,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6373,8 +6895,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6385,8 +6908,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6397,8 +6921,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6409,8 +6934,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6421,8 +6947,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6433,8 +6960,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6445,8 +6974,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6457,8 +6987,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6469,8 +7000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6481,8 +7013,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6493,8 +7026,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6524,8 +7058,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6536,8 +7071,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6548,8 +7084,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6560,8 +7097,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6572,8 +7111,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6584,8 +7124,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6596,8 +7138,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6608,8 +7152,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6620,8 +7165,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6632,8 +7178,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6644,8 +7191,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6656,8 +7205,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6668,8 +7218,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6680,8 +7231,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -6711,8 +7264,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6723,8 +7277,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "asn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6735,8 +7290,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6747,8 +7303,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6759,8 +7316,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "contact_email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6771,8 +7329,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "contact_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6783,8 +7342,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "contact_phone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6795,8 +7355,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6807,8 +7368,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6819,8 +7381,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6831,8 +7394,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6843,8 +7407,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6855,8 +7421,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6867,8 +7435,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6879,8 +7448,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6891,8 +7461,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6903,8 +7474,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6915,8 +7487,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6927,8 +7500,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6939,8 +7513,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6951,8 +7526,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6963,8 +7540,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6975,8 +7553,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6987,8 +7566,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6999,8 +7579,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7011,8 +7593,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7023,8 +7606,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7035,8 +7619,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7066,8 +7651,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7078,8 +7664,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7090,8 +7677,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7102,8 +7690,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7114,8 +7703,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7126,8 +7717,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7138,8 +7730,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7150,8 +7744,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7162,8 +7758,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7174,8 +7771,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7186,8 +7784,10 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7198,8 +7798,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7210,8 +7812,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7222,8 +7825,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7253,8 +7858,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7265,8 +7871,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7277,8 +7884,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "domain",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7289,8 +7897,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7301,8 +7911,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7313,8 +7924,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "master",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7325,8 +7937,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7374,8 +7987,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7423,8 +8037,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7435,8 +8050,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7447,8 +8064,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7459,8 +8078,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7471,8 +8091,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7483,8 +8104,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7495,8 +8117,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -7507,8 +8130,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7519,8 +8144,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7531,8 +8157,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7543,8 +8170,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7555,8 +8184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7567,8 +8197,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -7579,8 +8210,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7591,8 +8223,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7603,8 +8236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7615,8 +8249,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -7646,8 +8281,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7658,8 +8294,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7670,8 +8307,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7719,8 +8357,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7750,8 +8389,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7781,8 +8421,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7812,8 +8453,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7843,8 +8485,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7874,8 +8517,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7886,8 +8530,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7898,8 +8543,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7947,8 +8593,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7959,8 +8606,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8010,8 +8658,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8022,8 +8671,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8034,8 +8684,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8065,8 +8716,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8077,8 +8729,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8089,8 +8742,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8101,8 +8755,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8113,8 +8768,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8125,8 +8782,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8137,8 +8795,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8149,8 +8808,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8180,8 +8840,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8192,8 +8854,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8204,8 +8868,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8216,8 +8882,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8247,8 +8915,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8278,8 +8947,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8290,8 +8960,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8302,8 +8973,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8314,8 +8986,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8326,8 +8999,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8338,8 +9013,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8350,8 +9026,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8362,8 +9039,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8374,8 +9052,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8386,8 +9065,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8435,8 +9115,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8447,8 +9128,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -8496,8 +9178,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8508,8 +9191,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8520,8 +9204,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8532,8 +9217,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8544,8 +9230,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8556,8 +9243,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8568,8 +9256,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "dns_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8580,8 +9269,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8592,8 +9283,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8604,8 +9296,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "nat_inside",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8616,8 +9309,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8628,8 +9323,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8640,8 +9337,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8652,8 +9350,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8701,8 +9400,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8713,8 +9413,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8725,8 +9426,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8737,8 +9439,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8749,8 +9452,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8761,8 +9465,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8773,8 +9479,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8785,8 +9492,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8797,8 +9505,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8809,8 +9518,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8821,8 +9531,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8832,9 +9543,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8845,8 +9557,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8857,8 +9571,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8869,8 +9585,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8881,8 +9599,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8893,8 +9612,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8905,8 +9625,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8936,8 +9657,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8948,8 +9670,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8960,8 +9683,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8972,8 +9696,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8984,8 +9710,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -8996,8 +9723,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9008,8 +9736,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9020,8 +9749,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9051,8 +9781,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -9063,8 +9794,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9075,8 +9807,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9087,8 +9820,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9099,8 +9833,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9111,8 +9846,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9123,8 +9860,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9135,8 +9873,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9147,8 +9886,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9159,8 +9899,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9190,8 +9931,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9221,8 +9963,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9252,8 +9995,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9264,8 +10008,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9276,8 +10021,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9288,8 +10034,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9300,8 +10048,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9312,8 +10062,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9324,8 +10075,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9336,8 +10088,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9347,9 +10100,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9360,8 +10114,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9372,8 +10128,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9384,8 +10142,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9396,8 +10156,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9408,8 +10169,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9439,8 +10201,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9451,8 +10214,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9463,8 +10227,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9475,8 +10240,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9487,8 +10254,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9499,8 +10267,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9511,8 +10280,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9523,8 +10293,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9535,8 +10306,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9566,8 +10338,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9669,8 +10442,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9700,8 +10474,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9731,8 +10506,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9762,8 +10538,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9793,8 +10570,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9824,8 +10602,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9855,8 +10634,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9886,8 +10666,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9989,8 +10770,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10001,8 +10783,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10013,8 +10796,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10025,8 +10809,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10037,8 +10822,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10049,8 +10836,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10061,8 +10850,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10073,8 +10863,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10085,8 +10876,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10116,8 +10908,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10128,8 +10921,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10140,8 +10934,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10152,8 +10947,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10164,8 +10961,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10176,8 +10974,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10188,8 +10988,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10200,8 +11002,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10212,8 +11015,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10224,8 +11028,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10236,8 +11042,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10248,8 +11055,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -10279,8 +11088,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10328,8 +11138,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10359,8 +11170,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10408,8 +11220,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10420,8 +11233,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10432,8 +11246,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10444,8 +11259,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10456,8 +11273,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10468,8 +11287,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10480,8 +11300,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10492,8 +11313,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10503,9 +11325,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10516,8 +11339,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10528,8 +11353,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10540,8 +11366,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10571,8 +11399,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10583,8 +11412,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10595,8 +11425,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10607,8 +11438,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10619,8 +11452,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10631,8 +11465,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10643,8 +11478,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10674,8 +11510,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10686,8 +11523,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10698,8 +11536,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10710,8 +11549,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10722,8 +11563,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10734,8 +11576,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10746,8 +11589,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10777,8 +11621,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10789,8 +11634,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10801,8 +11647,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10813,8 +11660,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10825,8 +11673,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10837,8 +11686,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10849,8 +11699,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10861,8 +11713,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10873,8 +11726,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10885,8 +11739,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10897,8 +11752,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10909,8 +11765,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10921,8 +11778,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10933,8 +11791,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10945,8 +11804,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10957,8 +11818,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -10969,8 +11832,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10981,8 +11845,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11012,8 +11877,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11024,8 +11890,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11036,8 +11903,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11048,8 +11916,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11060,8 +11929,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11072,8 +11942,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -11084,8 +11955,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11096,8 +11969,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11108,8 +11982,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11120,8 +11995,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11132,8 +12008,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11144,8 +12021,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11156,8 +12034,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11168,8 +12048,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11180,8 +12061,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11192,8 +12074,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11204,8 +12087,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.1/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.1/summary.txt
@@ -117,947 +117,751 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
-dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
 ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
 ipam.role => extras.role
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
-dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
 dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-account (DATA) => value_importer => account (CharField)
-admin_contact (DATA) => value_importer => admin_contact (TextField)
-asn (DATA) => integer_importer => asn (BigIntegerField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-noc_contact (DATA) => value_importer => noc_contact (TextField)
-portal_url (DATA) => value_importer => portal_url (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+account => value_importer => account (CharField)
+admin_contact => value_importer => admin_contact (TextField)
+asn => integer_importer => asn (BigIntegerField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+noc_contact => value_importer => noc_contact (TextField)
+portal_url => value_importer => portal_url (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-_termination_a_device (DATA) => NO IMPORTER => NO TARGET
-_termination_b_device (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => NO IMPORTER => NO TARGET
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
-* dcim.cabletermination => dcim.cable **************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_abs_length => NO IMPORTER => NO TARGET
+_termination_a_device => NO IMPORTER => NO TARGET
+_termination_b_device => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+tenant => NO IMPORTER => NO TARGET
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-device_role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+device_role => relation_importer => role_id (RoleField)
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
 * dcim.frontport => dcim.frontport *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-rf_channel (DATA) => NO IMPORTER => NO TARGET
-rf_channel_frequency (DATA) => NO IMPORTER => NO TARGET
-rf_channel_width (DATA) => NO IMPORTER => NO TARGET
-rf_role (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-tx_power (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-wireless_lans (DATA) => NO IMPORTER => NO TARGET
-wireless_link (DATA) => NO IMPORTER => NO TARGET
-wwn (DATA) => NO IMPORTER => NO TARGET
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+rf_channel => NO IMPORTER => NO TARGET
+rf_channel_frequency => NO IMPORTER => NO TARGET
+rf_channel_width => NO IMPORTER => NO TARGET
+rf_role => NO IMPORTER => NO TARGET
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+tx_power => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+wireless_lans => NO IMPORTER => NO TARGET
+wireless_link => NO IMPORTER => NO TARGET
+wwn => NO IMPORTER => NO TARGET
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+tenant => relation_importer => tenant_id (ForeignKey)
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-napalm_args (DATA) => json_importer => napalm_args (JSONField)
-napalm_driver (DATA) => value_importer => napalm_driver (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+napalm_args => json_importer => napalm_args (JSONField)
+napalm_driver => value_importer => napalm_driver (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackreservation => dcim.rackreservation *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-units (DATA) (CUSTOM) => units_importer => units (JSONField)
-user (DATA) => relation_importer => user_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+rack => relation_importer => rack_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+units => units_importer => units (JSONField)
+user => relation_importer => user_id (ForeignKey)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asn (DATA) => integer_importer => asn (BigIntegerField)
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-contact_email (DATA) => value_importer => contact_email (CharField)
-contact_name (DATA) => value_importer => contact_name (CharField)
-contact_phone (DATA) => value_importer => contact_phone (CharField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+asn => integer_importer => asn (BigIntegerField)
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+contact_email => value_importer => contact_email (CharField)
+contact_name => value_importer => contact_name (CharField)
+contact_phone => value_importer => contact_phone (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (DATA) (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => constant_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.virtualchassis => dcim.virtualchassis *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-domain (DATA) => value_importer => domain (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-master (DATA) => relation_importer => master_id (OneToOneField)
-name (DATA) => value_importer => name (CharField)
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+domain => value_importer => domain (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+master => relation_importer => master_id (OneToOneField)
+name => value_importer => name (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (CUSTOM) => choices_importer => Custom Target
-choices (DATA) (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-required (DATA) => value_importer => required (BooleanField)
-type (DATA) => value_importer => type (CharField)
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
+choices => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+required => value_importer => required (BooleanField)
+type => value_importer => type (CharField)
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.tag => extras.tag *************************************************************************
-color (DATA) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (DATA) => tagged_object_importer => content_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (DATA) (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (DATA) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+content_type => tagged_object_importer => content_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_id => tagged_object_importer => object_id (UUIDField)
+tag => tagged_object_importer => tag_id (ForeignKey)
 * ipam.aggregate => ipam.prefix ********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.ipaddress => ipam.ipaddress *****************************************************************
-address (DATA) => value_importer => address (Property)
-assigned_object_id (DATA) => NO IMPORTER => NO TARGET
-assigned_object_type (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-dns_name (DATA) => value_importer => dns_name (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-nat_inside (DATA) => relation_importer => nat_inside_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
+address => value_importer => address (Property)
+assigned_object_id => NO IMPORTER => NO TARGET
+assigned_object_type => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+dns_name => value_importer => dns_name (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+nat_inside => relation_importer => nat_inside_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* ipam.routetarget => ipam.routetarget *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.vlan => ipam.vlan ***************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
-* ipam.vrf => ipam.vrf *****************************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+_name => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.2/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.2/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -88,8 +91,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -119,8 +124,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -152,8 +158,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +171,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +197,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -212,8 +223,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -224,8 +236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -248,8 +262,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -260,8 +276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -284,8 +303,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -296,8 +317,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -327,8 +349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +362,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +375,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +388,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +441,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -423,8 +454,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -435,8 +467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,8 +480,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -459,8 +494,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -471,8 +507,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +521,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -495,8 +535,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -526,8 +568,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -538,8 +581,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -550,8 +594,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +607,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +620,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +633,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -610,8 +660,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -622,8 +673,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -634,8 +686,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -646,8 +699,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +712,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -670,8 +725,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -681,9 +737,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -694,8 +751,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -706,8 +765,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +778,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -730,8 +791,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -761,8 +823,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -773,8 +836,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -785,8 +849,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -809,8 +876,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -821,8 +889,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -833,8 +902,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -864,8 +934,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -876,8 +947,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "admin_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -888,8 +960,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "asn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +973,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +986,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +999,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -948,8 +1025,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -960,8 +1039,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -972,8 +1052,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -984,8 +1065,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "noc_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -996,8 +1078,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "portal_url",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1008,8 +1091,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1039,8 +1123,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1136,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1149,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1162,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1087,8 +1175,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1189,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1111,8 +1202,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1123,8 +1215,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1135,8 +1228,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "service_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1169,8 +1263,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1181,8 +1277,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1193,8 +1290,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1224,8 +1322,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1236,8 +1335,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_termination_a_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1348,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_termination_b_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1361,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1387,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1296,8 +1400,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1308,8 +1414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1320,8 +1427,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1332,8 +1440,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1344,8 +1453,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1356,8 +1466,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1368,8 +1480,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1380,8 +1493,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1392,8 +1506,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1404,8 +1519,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1416,8 +1532,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1428,8 +1545,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1459,8 +1577,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1490,8 +1609,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1521,8 +1641,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1533,8 +1654,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1545,8 +1667,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1557,8 +1680,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1693,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1706,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1719,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1732,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1617,8 +1745,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1758,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1641,8 +1772,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1785,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1665,8 +1798,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1677,8 +1811,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1689,8 +1824,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1701,8 +1837,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1713,8 +1850,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1744,8 +1882,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1756,8 +1895,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1768,8 +1908,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1921,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1792,8 +1934,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1804,8 +1948,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1816,8 +1961,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1828,8 +1974,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1840,8 +1987,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1852,8 +2000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1883,8 +2032,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1914,8 +2064,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1945,8 +2096,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1957,8 +2109,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1969,8 +2122,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2135,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2148,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2005,8 +2161,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2174,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2187,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2041,8 +2201,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2053,8 +2214,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2227,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2077,8 +2241,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2089,8 +2254,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2101,8 +2267,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2113,8 +2281,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2294,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2137,8 +2307,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2320,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2161,8 +2333,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2346,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2184,9 +2358,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2197,8 +2372,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2209,8 +2385,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2221,8 +2398,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2233,8 +2412,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2245,8 +2426,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2257,8 +2439,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2269,8 +2452,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2281,8 +2465,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2312,8 +2497,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2324,8 +2510,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2336,8 +2523,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2348,8 +2536,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2360,8 +2549,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2372,8 +2562,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2384,8 +2576,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2396,8 +2589,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2408,8 +2602,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2420,8 +2615,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2451,8 +2647,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2463,8 +2660,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2475,8 +2673,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2487,8 +2686,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2499,8 +2699,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2511,8 +2713,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2523,8 +2726,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2535,8 +2739,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2566,8 +2771,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2578,8 +2785,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2590,8 +2798,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2602,8 +2811,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2614,8 +2824,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2626,8 +2837,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2638,8 +2851,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2650,8 +2864,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2662,8 +2877,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2674,8 +2890,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2705,20 +2922,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2729,8 +2935,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2741,8 +2948,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2753,8 +2961,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2765,8 +2974,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2777,8 +2988,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2789,8 +3003,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2801,8 +3016,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2813,8 +3029,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2825,8 +3043,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2837,8 +3057,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2849,8 +3070,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2861,8 +3084,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2873,8 +3097,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2885,8 +3110,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 }
@@ -2916,8 +3142,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2928,8 +3155,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2940,8 +3168,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2952,8 +3181,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2964,8 +3194,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2976,8 +3207,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2988,8 +3220,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3000,8 +3233,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3012,8 +3246,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3024,8 +3259,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3036,8 +3273,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3048,8 +3286,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3060,8 +3299,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3072,8 +3312,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3084,8 +3325,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3096,8 +3338,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3108,8 +3351,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3120,8 +3364,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3151,8 +3396,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3163,8 +3409,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3175,8 +3422,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3187,8 +3435,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3199,8 +3448,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3211,8 +3461,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3223,8 +3475,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3235,8 +3488,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3247,8 +3501,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3259,8 +3514,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3271,8 +3527,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3283,8 +3541,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3295,8 +3554,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3326,8 +3586,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3338,8 +3599,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3350,8 +3612,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3362,8 +3625,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3374,8 +3638,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3386,8 +3651,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3664,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3677,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3422,8 +3690,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3434,8 +3703,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3446,8 +3716,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "duplex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3458,8 +3729,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3470,8 +3742,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3482,8 +3756,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3494,8 +3769,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3506,8 +3782,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3518,8 +3795,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3530,8 +3808,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3542,8 +3821,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3554,8 +3834,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3566,8 +3847,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3578,8 +3860,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3590,8 +3873,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3602,8 +3886,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3614,8 +3900,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3626,8 +3913,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_frequency",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3638,8 +3926,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3650,8 +3939,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3662,8 +3952,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3674,8 +3965,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3686,8 +3978,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3698,8 +3991,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tx_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3710,8 +4004,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3722,8 +4017,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3734,8 +4030,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3746,8 +4043,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_lans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3758,8 +4056,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_link",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3770,8 +4069,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wwn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3801,8 +4101,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3813,8 +4114,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3825,8 +4127,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3837,8 +4140,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3849,8 +4153,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3861,8 +4167,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3873,8 +4180,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3885,8 +4193,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3897,8 +4206,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3909,8 +4219,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3921,8 +4232,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3952,8 +4264,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3964,8 +4277,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3976,8 +4290,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3988,8 +4303,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4000,8 +4316,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4067,8 +4384,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4079,8 +4397,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4091,8 +4410,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4103,8 +4423,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4115,8 +4437,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4127,8 +4450,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4139,8 +4464,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4151,8 +4478,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4163,8 +4491,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4175,8 +4504,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4187,8 +4518,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4199,8 +4532,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4211,8 +4546,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4223,8 +4559,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4235,8 +4572,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4247,8 +4585,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4278,8 +4618,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4290,8 +4631,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4302,8 +4645,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4314,8 +4658,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4326,8 +4671,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4338,8 +4684,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4350,8 +4697,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4362,8 +4710,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4374,8 +4723,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4405,8 +4755,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4417,8 +4768,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4429,8 +4781,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4441,8 +4794,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4453,8 +4809,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4465,8 +4822,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4477,8 +4836,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4580,8 +4940,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4592,8 +4953,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4604,8 +4966,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4616,8 +4979,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4628,8 +4993,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4640,8 +5006,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4652,8 +5019,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4664,8 +5032,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "napalm_args",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4676,8 +5045,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "napalm_driver",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4688,8 +5058,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4719,8 +5090,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4731,8 +5103,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4743,8 +5116,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4755,8 +5129,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4767,8 +5142,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4779,8 +5155,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4791,8 +5168,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4803,8 +5181,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4815,8 +5194,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4827,8 +5207,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4839,8 +5221,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4851,8 +5234,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4863,8 +5247,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -4875,8 +5260,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4887,8 +5273,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -4899,8 +5286,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4911,8 +5299,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4923,8 +5312,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4935,8 +5326,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -4947,8 +5339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -4959,8 +5352,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -4990,8 +5384,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5002,8 +5397,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5014,8 +5410,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5026,8 +5423,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5038,8 +5436,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5050,8 +5449,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5062,8 +5462,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5074,8 +5475,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5086,8 +5488,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5098,8 +5501,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5110,8 +5514,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5122,8 +5528,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5134,8 +5541,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5146,8 +5554,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5158,8 +5567,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5170,8 +5580,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5182,8 +5593,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5194,8 +5606,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5225,8 +5638,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5237,8 +5651,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5249,8 +5664,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5261,8 +5677,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5273,8 +5690,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5285,8 +5703,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5297,8 +5717,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5309,8 +5730,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5321,8 +5743,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5333,8 +5756,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5345,8 +5769,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5357,8 +5783,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5388,8 +5815,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5400,8 +5828,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5412,8 +5841,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5424,8 +5855,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5436,8 +5868,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5448,8 +5882,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5459,9 +5894,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5472,8 +5908,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5503,8 +5941,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5515,8 +5954,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5527,8 +5967,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5539,8 +5980,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5551,8 +5993,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5563,8 +6006,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5575,8 +6019,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5587,8 +6032,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5599,8 +6045,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5611,8 +6058,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5623,8 +6071,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5635,8 +6085,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5647,8 +6098,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5659,8 +6111,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5671,8 +6124,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5683,8 +6137,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5695,8 +6150,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5707,8 +6163,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5738,8 +6195,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5750,8 +6208,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5762,8 +6221,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5774,8 +6234,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5786,8 +6247,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5798,8 +6260,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5810,8 +6274,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5822,8 +6287,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5834,8 +6300,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5846,8 +6313,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5858,8 +6326,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5870,8 +6339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5901,8 +6371,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5913,8 +6384,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5925,8 +6397,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5937,8 +6410,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5949,8 +6423,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5961,8 +6436,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -5973,8 +6449,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5985,8 +6462,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5997,8 +6476,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6009,8 +6489,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6021,8 +6503,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6033,8 +6516,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6045,8 +6529,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6057,8 +6542,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6068,9 +6554,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6081,8 +6568,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6093,8 +6582,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6105,8 +6595,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6117,8 +6609,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6129,8 +6623,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6141,8 +6636,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6153,8 +6649,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -6165,8 +6662,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -6196,8 +6694,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6208,8 +6707,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6220,8 +6720,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6232,8 +6733,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6244,8 +6747,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6256,8 +6760,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6268,8 +6773,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6280,8 +6786,10 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6292,8 +6800,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6323,8 +6832,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -6335,8 +6846,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6347,8 +6859,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6359,8 +6872,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6371,8 +6885,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6383,8 +6898,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6395,8 +6912,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6407,8 +6925,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6419,8 +6938,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6450,8 +6970,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6462,8 +6983,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_link_peer_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6474,8 +6996,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6486,8 +7009,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6498,8 +7022,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6510,8 +7035,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6522,8 +7048,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6534,8 +7061,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6546,8 +7074,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6558,8 +7087,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6570,8 +7101,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6582,8 +7114,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6594,8 +7127,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6606,8 +7140,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6618,8 +7153,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6630,8 +7166,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6642,8 +7179,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6673,8 +7211,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6685,8 +7224,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6697,8 +7237,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6709,8 +7250,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6721,8 +7263,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6733,8 +7276,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6745,8 +7290,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6757,8 +7303,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6769,8 +7316,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6781,8 +7329,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6793,8 +7342,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6805,8 +7355,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6836,8 +7387,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6848,8 +7400,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6860,8 +7413,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6872,8 +7426,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6884,8 +7440,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6896,8 +7453,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6908,8 +7467,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6920,8 +7481,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6932,8 +7494,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6944,8 +7507,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6956,8 +7520,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6968,8 +7534,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6980,8 +7547,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6992,8 +7560,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7023,8 +7593,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7035,8 +7606,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7047,8 +7619,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7059,8 +7632,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7071,8 +7645,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7083,8 +7658,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7095,8 +7671,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7107,8 +7684,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7119,8 +7698,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7131,8 +7712,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7143,8 +7725,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7155,8 +7738,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7167,8 +7751,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7179,8 +7764,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7191,8 +7777,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7203,8 +7790,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7215,8 +7803,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7227,8 +7817,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7239,8 +7830,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7251,8 +7843,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7263,8 +7856,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7275,8 +7870,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7287,8 +7883,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7299,8 +7896,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7330,8 +7928,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7342,8 +7941,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7354,8 +7954,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7366,8 +7967,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7378,8 +7980,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7390,8 +7994,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7402,8 +8007,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7414,8 +8021,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7426,8 +8035,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7438,8 +8048,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7450,8 +8061,10 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7462,8 +8075,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7474,8 +8089,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7486,8 +8102,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7517,8 +8135,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7529,8 +8148,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7541,8 +8161,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "domain",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7553,8 +8174,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7565,8 +8188,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7577,8 +8201,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "master",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7589,8 +8214,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7638,8 +8264,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7687,8 +8314,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7699,8 +8327,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7711,8 +8341,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7723,8 +8355,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7735,8 +8368,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7747,8 +8381,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7759,8 +8394,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -7771,8 +8407,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7783,8 +8421,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7795,8 +8434,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7807,8 +8447,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7819,8 +8461,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7831,8 +8474,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7843,8 +8487,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -7855,8 +8500,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7867,8 +8513,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7879,8 +8526,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7891,8 +8539,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -7922,8 +8571,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7934,8 +8584,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7946,8 +8597,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7995,8 +8647,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8026,8 +8679,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8057,8 +8711,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8088,8 +8743,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8119,8 +8775,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8150,8 +8807,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8162,8 +8820,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8174,8 +8833,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8223,8 +8883,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8235,8 +8896,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8286,8 +8948,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8298,8 +8961,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8310,8 +8974,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8341,8 +9006,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8353,8 +9019,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8365,8 +9032,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8377,8 +9045,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8389,8 +9058,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8401,8 +9072,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8413,8 +9085,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8425,8 +9098,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8456,8 +9130,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8468,8 +9144,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8480,8 +9158,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8492,8 +9172,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8523,8 +9205,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8554,8 +9237,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8566,8 +9250,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8578,8 +9263,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8590,8 +9276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8602,8 +9289,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8614,8 +9303,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8626,8 +9316,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8638,8 +9329,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8650,8 +9342,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8662,8 +9355,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8711,8 +9405,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8723,8 +9418,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -8772,8 +9468,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8784,8 +9481,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8796,8 +9494,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8808,8 +9507,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8820,8 +9520,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8832,8 +9533,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8844,8 +9546,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "dns_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8856,8 +9559,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8868,8 +9573,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8880,8 +9586,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "nat_inside",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8892,8 +9599,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8904,8 +9613,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8916,8 +9627,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8928,8 +9640,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8977,8 +9690,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8989,8 +9703,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9001,8 +9716,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9013,8 +9729,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9025,8 +9742,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9037,8 +9755,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9049,8 +9769,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9061,8 +9782,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9073,8 +9795,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9085,8 +9808,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9097,8 +9821,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9108,9 +9833,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9121,8 +9847,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9133,8 +9861,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9145,8 +9875,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9157,8 +9889,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9169,8 +9902,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9181,8 +9915,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9212,8 +9947,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9224,8 +9960,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9236,8 +9973,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9248,8 +9986,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9260,8 +10000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -9272,8 +10013,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9284,8 +10026,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9296,8 +10039,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9327,8 +10071,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -9339,8 +10084,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9351,8 +10097,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9363,8 +10110,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9375,8 +10123,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9387,8 +10136,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9399,8 +10150,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9411,8 +10163,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9423,8 +10176,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9435,8 +10189,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9466,8 +10221,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9478,8 +10234,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9490,8 +10247,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9502,8 +10260,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9514,8 +10274,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9526,8 +10287,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9538,8 +10300,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9569,8 +10332,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9618,8 +10382,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9630,8 +10395,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9642,8 +10408,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9654,8 +10421,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9666,8 +10435,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9678,8 +10449,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9690,8 +10462,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9702,8 +10475,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9713,9 +10487,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9726,8 +10501,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9738,8 +10515,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9750,8 +10529,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9762,8 +10543,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9774,8 +10556,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9805,8 +10588,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9817,8 +10601,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9829,8 +10614,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9841,8 +10627,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9853,8 +10641,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9865,8 +10654,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9877,8 +10667,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "min_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9889,8 +10680,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9901,8 +10693,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9913,8 +10706,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9925,8 +10719,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9956,8 +10751,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9968,8 +10764,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9980,8 +10777,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9992,8 +10790,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enforce_unique",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10004,8 +10803,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "export_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10016,8 +10816,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10028,8 +10830,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "import_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10040,8 +10843,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10052,8 +10856,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10064,8 +10869,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "rd",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10076,8 +10882,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10179,8 +10986,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10210,8 +11018,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10241,8 +11050,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10272,8 +11082,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10303,8 +11114,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10334,8 +11146,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10365,8 +11178,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10396,8 +11210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10499,8 +11314,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10511,8 +11327,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10523,8 +11340,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10535,8 +11353,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10547,8 +11366,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10559,8 +11380,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10571,8 +11394,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10583,8 +11407,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10595,8 +11420,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10626,8 +11452,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10638,8 +11465,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10650,8 +11478,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10662,8 +11491,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10674,8 +11505,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10686,8 +11518,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10698,8 +11532,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10710,8 +11546,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10722,8 +11559,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10734,8 +11572,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10746,8 +11586,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10758,8 +11599,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -10789,8 +11632,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10838,8 +11682,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10869,8 +11714,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10918,8 +11764,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10930,8 +11777,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10942,8 +11790,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10954,8 +11803,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10966,8 +11817,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10978,8 +11831,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10990,8 +11844,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11002,8 +11857,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11013,9 +11869,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11026,8 +11883,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11038,8 +11897,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11050,8 +11910,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11081,8 +11943,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11093,8 +11956,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11105,8 +11969,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11117,8 +11982,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11129,8 +11996,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11141,8 +12009,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11153,8 +12022,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11184,8 +12054,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11196,8 +12067,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11208,8 +12080,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11220,8 +12093,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11232,8 +12107,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11244,8 +12120,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11256,8 +12133,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11287,8 +12165,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11299,8 +12178,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11311,8 +12191,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11323,8 +12204,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11335,8 +12217,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11347,8 +12230,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11359,8 +12243,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11371,8 +12257,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11383,8 +12270,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11395,8 +12283,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11407,8 +12296,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11419,8 +12309,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11431,8 +12322,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11443,8 +12335,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11455,8 +12348,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11467,8 +12362,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11479,8 +12376,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11491,8 +12389,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11522,8 +12421,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11534,8 +12434,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11546,8 +12447,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11558,8 +12460,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11570,8 +12473,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11582,8 +12486,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -11594,8 +12499,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11606,8 +12513,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11618,8 +12526,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11630,8 +12539,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11642,8 +12552,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11654,8 +12565,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11666,8 +12578,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11678,8 +12592,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11690,8 +12605,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11702,8 +12618,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11714,8 +12631,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11726,8 +12644,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.2/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.2/summary.txt
@@ -119,1001 +119,788 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
-dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
-dcim.inventoryitemrole => dcim.inventoryitemrole | Disabled with reason: Nautobot content type: `dcim.inventoryitemrole` not found
-dcim.inventoryitemtemplate => dcim.inventoryitemtemplate | Disabled with reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-dcim.module => dcim.module | Disabled with reason: Nautobot content type: `dcim.module` not found
-dcim.modulebay => dcim.modulebay | Disabled with reason: Nautobot content type: `dcim.modulebay` not found
-dcim.modulebaytemplate => dcim.modulebaytemplate | Disabled with reason: Nautobot content type: `dcim.modulebaytemplate` not found
-dcim.moduletype => dcim.moduletype | Disabled with reason: Nautobot content type: `dcim.moduletype` not found
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
 ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
 ipam.role => extras.role
-ipam.servicetemplate => ipam.servicetemplate | Disabled with reason: Nautobot content type: `ipam.servicetemplate` not found
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
-dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
 dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-account (DATA) => value_importer => account (CharField)
-admin_contact (DATA) => value_importer => admin_contact (TextField)
-asn (DATA) => integer_importer => asn (BigIntegerField)
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-noc_contact (DATA) => value_importer => noc_contact (TextField)
-portal_url (DATA) => value_importer => portal_url (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+account => value_importer => account (CharField)
+admin_contact => value_importer => admin_contact (TextField)
+asn => integer_importer => asn (BigIntegerField)
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+noc_contact => value_importer => noc_contact (TextField)
+portal_url => value_importer => portal_url (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-service_id (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
+service_id => NO IMPORTER => NO TARGET
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-_termination_a_device (DATA) => NO IMPORTER => NO TARGET
-_termination_b_device (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => NO IMPORTER => NO TARGET
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
-* dcim.cabletermination => dcim.cable **************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_abs_length => NO IMPORTER => NO TARGET
+_termination_a_device => NO IMPORTER => NO TARGET
+_termination_b_device => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+tenant => NO IMPORTER => NO TARGET
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-device_role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+device_role => relation_importer => role_id (RoleField)
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
 * dcim.frontport => dcim.frontport *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-duplex (DATA) => NO IMPORTER => NO TARGET
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-module (DATA) => NO IMPORTER => NO TARGET
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-rf_channel (DATA) => NO IMPORTER => NO TARGET
-rf_channel_frequency (DATA) => NO IMPORTER => NO TARGET
-rf_channel_width (DATA) => NO IMPORTER => NO TARGET
-rf_role (DATA) => NO IMPORTER => NO TARGET
-speed (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-tx_power (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-wireless_lans (DATA) => NO IMPORTER => NO TARGET
-wireless_link (DATA) => NO IMPORTER => NO TARGET
-wwn (DATA) => NO IMPORTER => NO TARGET
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+duplex => NO IMPORTER => NO TARGET
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+module => NO IMPORTER => NO TARGET
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+rf_channel => NO IMPORTER => NO TARGET
+rf_channel_frequency => NO IMPORTER => NO TARGET
+rf_channel_width => NO IMPORTER => NO TARGET
+rf_role => NO IMPORTER => NO TARGET
+speed => NO IMPORTER => NO TARGET
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+tx_power => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
+wireless_lans => NO IMPORTER => NO TARGET
+wireless_link => NO IMPORTER => NO TARGET
+wwn => NO IMPORTER => NO TARGET
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.inventoryitemrole => dcim.inventoryitemrole *************************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemrole` not found
-* dcim.inventoryitemtemplate => dcim.inventoryitemtemplate *****************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+tenant => relation_importer => tenant_id (ForeignKey)
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-* dcim.module => dcim.module ***********************************************************************
-    Disable reason: Nautobot content type: `dcim.module` not found
-* dcim.modulebay => dcim.modulebay *****************************************************************
-    Disable reason: Nautobot content type: `dcim.modulebay` not found
-* dcim.modulebaytemplate => dcim.modulebaytemplate *************************************************
-    Disable reason: Nautobot content type: `dcim.modulebaytemplate` not found
-* dcim.moduletype => dcim.moduletype ***************************************************************
-    Disable reason: Nautobot content type: `dcim.moduletype` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-napalm_args (DATA) => json_importer => napalm_args (JSONField)
-napalm_driver (DATA) => value_importer => napalm_driver (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+napalm_args => json_importer => napalm_args (JSONField)
+napalm_driver => value_importer => napalm_driver (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackreservation => dcim.rackreservation *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-units (DATA) (CUSTOM) => units_importer => units (JSONField)
-user (DATA) => relation_importer => user_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+rack => relation_importer => rack_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+units => units_importer => units (JSONField)
+user => relation_importer => user_id (ForeignKey)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_link_peer_id (DATA) => NO IMPORTER => NO TARGET
-_link_peer_type (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_link_peer_id => NO IMPORTER => NO TARGET
+_link_peer_type => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (DATA) (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => constant_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.virtualchassis => dcim.virtualchassis *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-domain (DATA) => value_importer => domain (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-master (DATA) => relation_importer => master_id (OneToOneField)
-name (DATA) => value_importer => name (CharField)
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+domain => value_importer => domain (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+master => relation_importer => master_id (OneToOneField)
+name => value_importer => name (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (CUSTOM) => choices_importer => Custom Target
-choices (DATA) (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-object_type (DATA) => NO IMPORTER => NO TARGET
-required (DATA) => value_importer => required (BooleanField)
-type (DATA) => value_importer => type (CharField)
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
+choices => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+object_type => NO IMPORTER => NO TARGET
+required => value_importer => required (BooleanField)
+type => value_importer => type (CharField)
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.tag => extras.tag *************************************************************************
-color (DATA) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (DATA) => tagged_object_importer => content_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (DATA) (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (DATA) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+content_type => tagged_object_importer => content_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_id => tagged_object_importer => object_id (UUIDField)
+tag => tagged_object_importer => tag_id (ForeignKey)
 * ipam.aggregate => ipam.prefix ********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.ipaddress => ipam.ipaddress *****************************************************************
-address (DATA) => value_importer => address (Property)
-assigned_object_id (DATA) => NO IMPORTER => NO TARGET
-assigned_object_type (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-dns_name (DATA) => value_importer => dns_name (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-nat_inside (DATA) => relation_importer => nat_inside_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
+address => value_importer => address (Property)
+assigned_object_id => NO IMPORTER => NO TARGET
+assigned_object_type => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+dns_name => value_importer => dns_name (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+nat_inside => relation_importer => nat_inside_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.routetarget => ipam.routetarget *************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.servicetemplate => ipam.servicetemplate *****************************************************
-    Disable reason: Nautobot content type: `ipam.servicetemplate` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.vlan => ipam.vlan ***************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-max_vid (DATA) => NO IMPORTER => NO TARGET
-min_vid (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+max_vid => NO IMPORTER => NO TARGET
+min_vid => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * ipam.vrf => ipam.vrf *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enforce_unique (DATA) => NO IMPORTER => NO TARGET
-export_targets (DATA) => uuids_importer => export_targets (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-import_targets (DATA) => uuids_importer => import_targets (ManyToManyField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rd (DATA) => value_importer => rd (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enforce_unique => NO IMPORTER => NO TARGET
+export_targets => uuids_importer => export_targets (ManyToManyField)
+id => uid_from_data => id (UUIDField)
+import_targets => uuids_importer => import_targets (ManyToManyField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rd => value_importer => rd (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+_name => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.3/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.3/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -88,8 +91,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -119,8 +124,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -152,8 +158,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +171,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +197,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -212,8 +223,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -224,8 +236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -248,8 +262,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -260,8 +276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -284,8 +303,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -296,8 +317,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -327,8 +349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +362,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +375,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +388,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +441,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -423,8 +454,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -435,8 +467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,8 +480,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -459,8 +494,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -471,8 +507,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +521,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "termination_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -495,8 +534,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -507,8 +548,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -538,8 +581,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -550,8 +594,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +607,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +620,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +633,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -610,8 +659,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -622,8 +673,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -634,8 +686,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -646,8 +699,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +712,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -670,8 +725,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -682,8 +738,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -693,9 +750,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -706,8 +764,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +778,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -730,8 +791,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -742,8 +804,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -773,8 +836,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -785,8 +849,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -809,8 +875,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -821,8 +889,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -833,8 +902,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -845,8 +915,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -876,8 +947,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -888,8 +960,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "admin_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +973,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "asn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +986,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +999,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -948,8 +1025,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -960,8 +1038,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -972,8 +1052,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -984,8 +1065,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -996,8 +1078,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "noc_contact",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1008,8 +1091,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "portal_url",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1020,8 +1104,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1051,8 +1136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1149,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1162,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1087,8 +1175,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1188,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1111,8 +1202,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1123,8 +1215,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1135,8 +1228,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1147,8 +1241,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "service_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1181,8 +1276,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1193,8 +1290,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1205,8 +1303,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1236,8 +1335,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1361,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1387,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1296,8 +1401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1308,8 +1414,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1320,8 +1427,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1332,8 +1440,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1344,8 +1453,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1356,8 +1467,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1368,8 +1480,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1399,8 +1512,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1430,8 +1544,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1442,8 +1557,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_location",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1454,8 +1570,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1466,8 +1583,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1478,8 +1596,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1490,8 +1610,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1502,8 +1623,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1514,8 +1636,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1526,8 +1649,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1557,8 +1681,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1694,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1707,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1720,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1733,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1617,8 +1746,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1759,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1641,8 +1772,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1785,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1665,8 +1799,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1677,8 +1812,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1689,8 +1825,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1701,8 +1838,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1713,8 +1851,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1725,8 +1864,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1737,8 +1877,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1768,8 +1909,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1922,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1792,8 +1935,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1804,8 +1948,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1816,8 +1961,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1828,8 +1975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1840,8 +1988,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1852,8 +2001,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1864,8 +2014,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1876,8 +2027,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1907,8 +2059,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1938,8 +2091,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1969,8 +2123,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2136,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2149,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2005,8 +2162,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2175,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2188,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2041,8 +2201,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2053,8 +2214,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2228,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2077,8 +2241,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2089,8 +2254,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2101,8 +2268,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2113,8 +2281,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2294,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2137,8 +2308,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2321,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2161,8 +2334,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2347,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2185,8 +2360,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2197,8 +2373,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2208,9 +2385,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2221,8 +2399,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2233,8 +2412,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2245,8 +2425,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2257,8 +2439,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2269,8 +2453,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2281,8 +2466,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2293,8 +2479,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2305,8 +2492,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2336,8 +2524,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2348,8 +2537,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2360,8 +2550,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2372,8 +2563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2384,8 +2576,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2396,8 +2589,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2408,8 +2603,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2420,8 +2616,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2432,8 +2629,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2444,8 +2642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2475,8 +2674,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2487,8 +2687,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2499,8 +2700,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2511,8 +2713,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2523,8 +2726,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2535,8 +2740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2547,8 +2753,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2559,8 +2766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2590,8 +2798,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2602,8 +2812,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2614,8 +2825,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2626,8 +2838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2638,8 +2851,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2650,8 +2864,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2662,8 +2878,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2674,8 +2891,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2686,8 +2904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2698,8 +2917,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2729,20 +2949,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2753,8 +2962,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2765,8 +2975,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2777,8 +2988,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2789,8 +3001,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2801,8 +3015,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2813,8 +3030,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2825,8 +3043,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2837,8 +3056,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2849,8 +3070,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2861,8 +3084,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2873,8 +3097,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2885,8 +3111,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2897,8 +3124,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2909,8 +3137,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 }
@@ -2940,8 +3169,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2952,8 +3182,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2964,8 +3195,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2976,8 +3208,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2988,8 +3221,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3000,8 +3234,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3012,8 +3247,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3024,8 +3260,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3036,8 +3273,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3048,8 +3287,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3060,8 +3300,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3072,8 +3313,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3084,8 +3326,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3096,8 +3339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3108,8 +3352,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3120,8 +3365,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3132,8 +3378,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3163,8 +3410,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3175,8 +3423,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3187,8 +3436,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3199,8 +3449,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3211,8 +3462,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3223,8 +3475,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3235,8 +3489,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3247,8 +3502,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3259,8 +3515,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3271,8 +3528,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3283,8 +3541,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3295,8 +3555,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3307,8 +3568,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3338,8 +3600,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3350,8 +3613,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3362,8 +3626,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3374,8 +3639,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3386,8 +3652,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3665,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3678,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3422,8 +3691,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3434,8 +3704,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3446,8 +3717,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "duplex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3458,8 +3730,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3470,8 +3743,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3482,8 +3757,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3494,8 +3770,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3506,8 +3783,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3518,8 +3796,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3530,8 +3809,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3542,8 +3822,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3554,8 +3835,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3566,8 +3848,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3578,8 +3861,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3590,8 +3874,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3602,8 +3887,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3614,8 +3901,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3626,8 +3914,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3638,8 +3927,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3650,8 +3940,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_frequency",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3662,8 +3953,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3674,8 +3966,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3686,8 +3979,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3698,8 +3992,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3710,8 +4005,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3722,8 +4018,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tx_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3734,8 +4031,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3746,8 +4044,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3758,8 +4057,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3770,8 +4070,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_lans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3782,8 +4083,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_link",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3794,8 +4096,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wwn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3825,8 +4128,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3837,8 +4141,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3849,8 +4154,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3861,8 +4167,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3873,8 +4180,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3885,8 +4194,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3897,8 +4207,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3909,8 +4220,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3921,8 +4233,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3933,8 +4246,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3945,8 +4259,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3957,8 +4272,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3969,8 +4285,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4000,8 +4317,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4012,8 +4330,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4024,8 +4343,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4036,8 +4356,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4048,8 +4369,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4115,8 +4437,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4127,8 +4450,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4139,8 +4463,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4151,8 +4476,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4163,8 +4490,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4175,8 +4503,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4187,8 +4517,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4199,8 +4531,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4211,8 +4544,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4223,8 +4557,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4235,8 +4571,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4247,8 +4585,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4259,8 +4599,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4271,8 +4612,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4283,8 +4626,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4295,8 +4639,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4326,8 +4672,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4338,8 +4685,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4350,8 +4699,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4362,8 +4712,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4374,8 +4725,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4386,8 +4738,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4398,8 +4751,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4410,8 +4764,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4422,8 +4777,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4453,8 +4809,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4465,8 +4822,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4477,8 +4835,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4489,8 +4848,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4501,8 +4863,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4513,8 +4876,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4525,8 +4890,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4628,8 +4994,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4640,8 +5007,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4652,8 +5020,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4664,8 +5033,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4676,8 +5047,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4688,8 +5060,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4700,8 +5073,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4712,8 +5086,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "napalm_args",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4724,8 +5099,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "napalm_driver",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4736,8 +5112,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4767,8 +5144,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4779,8 +5157,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4791,8 +5170,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4803,8 +5183,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4815,8 +5196,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4827,8 +5209,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4839,8 +5222,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4851,8 +5235,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4863,8 +5248,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4875,8 +5262,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4887,8 +5275,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4899,8 +5288,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -4911,8 +5301,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4923,8 +5314,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -4935,8 +5327,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4947,8 +5340,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4959,8 +5353,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4971,8 +5367,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -4983,8 +5380,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -4995,8 +5393,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -5026,8 +5425,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5038,8 +5438,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5050,8 +5451,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5062,8 +5464,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5074,8 +5477,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5086,8 +5490,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5098,8 +5503,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5110,8 +5516,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5122,8 +5529,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5134,8 +5542,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5146,8 +5556,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5158,8 +5569,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5170,8 +5582,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5182,8 +5595,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5194,8 +5608,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5206,8 +5621,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5218,8 +5634,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5249,8 +5666,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5261,8 +5679,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5273,8 +5692,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5285,8 +5705,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5297,8 +5718,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5309,8 +5731,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5321,8 +5745,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5333,8 +5758,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5345,8 +5771,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5357,8 +5784,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5369,8 +5797,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5381,8 +5811,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5412,8 +5843,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5424,8 +5856,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5436,8 +5869,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5448,8 +5883,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5460,8 +5896,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5472,8 +5910,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5483,9 +5922,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5496,8 +5936,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5527,8 +5969,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5539,8 +5982,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5551,8 +5995,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5563,8 +6008,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5575,8 +6021,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5587,8 +6034,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5599,8 +6047,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5611,8 +6060,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5623,8 +6073,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5635,8 +6086,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5647,8 +6100,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5659,8 +6113,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5671,8 +6126,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5683,8 +6139,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5695,8 +6152,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5707,8 +6165,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5719,8 +6178,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5750,8 +6210,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5762,8 +6223,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5774,8 +6236,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5786,8 +6249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5798,8 +6262,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5810,8 +6275,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5822,8 +6289,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5834,8 +6302,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5846,8 +6315,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5858,8 +6328,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5870,8 +6341,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5882,8 +6354,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5913,8 +6386,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5925,8 +6399,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5937,8 +6412,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5949,8 +6425,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5961,8 +6438,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5973,8 +6451,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -5985,8 +6464,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5997,8 +6477,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6009,8 +6491,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6021,8 +6504,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6033,8 +6518,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6045,8 +6531,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6057,8 +6544,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6069,8 +6557,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6080,9 +6569,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6093,8 +6583,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6105,8 +6597,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6117,8 +6610,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6129,8 +6624,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6141,8 +6638,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6153,8 +6651,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6165,8 +6664,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -6177,8 +6677,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -6208,8 +6709,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6220,8 +6722,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6232,8 +6735,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6244,8 +6748,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6256,8 +6762,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6268,8 +6775,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6280,8 +6788,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6292,8 +6801,10 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6304,8 +6815,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6335,8 +6847,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -6347,8 +6861,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6359,8 +6874,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6371,8 +6887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6383,8 +6900,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6395,8 +6913,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6407,8 +6927,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6419,8 +6940,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6431,8 +6953,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6462,8 +6985,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6474,8 +6998,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6486,8 +7011,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6498,8 +7024,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6510,8 +7037,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6522,8 +7050,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6534,8 +7063,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6546,8 +7076,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6558,8 +7089,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6570,8 +7103,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6582,8 +7116,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6594,8 +7129,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6606,8 +7142,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6618,8 +7155,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6630,8 +7168,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6642,8 +7181,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6673,8 +7213,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6685,8 +7226,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6697,8 +7239,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6709,8 +7252,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6721,8 +7265,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6733,8 +7278,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6745,8 +7292,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6757,8 +7305,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6769,8 +7318,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6781,8 +7331,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6793,8 +7344,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6805,8 +7357,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6836,8 +7389,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6848,8 +7402,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6860,8 +7415,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6872,8 +7428,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6884,8 +7442,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6896,8 +7455,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6908,8 +7469,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6920,8 +7483,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6932,8 +7496,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6944,8 +7509,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6956,8 +7522,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6968,8 +7536,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6980,8 +7549,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6992,8 +7562,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7023,8 +7595,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7035,8 +7608,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7047,8 +7621,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7059,8 +7634,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7071,8 +7647,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7083,8 +7660,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7095,8 +7673,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7107,8 +7686,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7119,8 +7700,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7131,8 +7714,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7143,8 +7727,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7155,8 +7740,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7167,8 +7753,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7179,8 +7766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7191,8 +7779,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7203,8 +7792,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7215,8 +7805,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7227,8 +7819,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7239,8 +7832,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7251,8 +7845,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7263,8 +7858,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7275,8 +7872,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7287,8 +7885,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7299,8 +7898,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7330,8 +7930,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7342,8 +7943,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7354,8 +7956,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7366,8 +7969,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7378,8 +7982,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7390,8 +7996,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7402,8 +8009,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7414,8 +8023,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7426,8 +8037,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7438,8 +8050,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7450,8 +8063,10 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7462,8 +8077,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7474,8 +8091,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7486,8 +8104,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7517,8 +8137,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7529,8 +8150,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7541,8 +8163,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "domain",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7553,8 +8176,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7565,8 +8190,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7577,8 +8203,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "master",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7589,8 +8216,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7638,8 +8266,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7687,8 +8316,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7699,8 +8329,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7711,8 +8343,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7723,8 +8357,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7735,8 +8370,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7747,8 +8383,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7759,8 +8396,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -7771,8 +8409,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "group_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7783,8 +8422,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7795,8 +8436,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7807,8 +8449,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7819,8 +8462,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7831,8 +8476,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7843,8 +8489,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7855,8 +8502,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -7867,8 +8515,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "ui_visibility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7879,8 +8528,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7891,8 +8541,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7903,8 +8554,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7915,8 +8567,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -7946,8 +8599,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7958,8 +8612,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7970,8 +8625,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8019,8 +8675,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8050,8 +8707,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8081,8 +8739,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8112,8 +8771,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8143,8 +8803,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8174,8 +8835,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8186,8 +8848,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8198,8 +8861,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8247,8 +8911,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8259,8 +8924,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8310,8 +8976,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8322,8 +8989,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8334,8 +9002,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8365,8 +9034,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8377,8 +9047,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8389,8 +9060,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8401,8 +9073,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8413,8 +9086,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8425,8 +9100,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8437,8 +9113,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8449,8 +9126,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8480,8 +9158,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8492,8 +9172,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8504,8 +9186,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8516,8 +9200,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8547,8 +9233,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8578,8 +9265,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8590,8 +9278,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8602,8 +9291,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8614,8 +9304,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8626,8 +9317,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8638,8 +9331,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8650,8 +9344,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8662,8 +9357,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8674,8 +9370,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8686,8 +9383,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8735,8 +9433,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8747,8 +9446,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -8796,8 +9496,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8808,8 +9509,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8820,8 +9522,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8832,8 +9535,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8844,8 +9548,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8856,8 +9561,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8868,8 +9574,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "dns_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8880,8 +9587,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8892,8 +9601,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8904,8 +9614,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "nat_inside",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8916,8 +9627,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8928,8 +9641,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -8940,8 +9655,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8952,8 +9668,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9037,8 +9754,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9049,8 +9767,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9061,8 +9780,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9073,8 +9793,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9085,8 +9806,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9097,8 +9819,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9109,8 +9833,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9121,8 +9846,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9133,8 +9859,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9145,8 +9872,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9157,8 +9885,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9168,9 +9897,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9181,8 +9911,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9193,8 +9925,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9205,8 +9939,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9217,8 +9953,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9229,8 +9966,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9241,8 +9979,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9272,8 +10011,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9284,8 +10024,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9296,8 +10037,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9308,8 +10050,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9320,8 +10064,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -9332,8 +10077,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9344,8 +10090,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9356,8 +10103,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9387,8 +10135,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -9399,8 +10148,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9411,8 +10161,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9423,8 +10174,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9435,8 +10187,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9447,8 +10200,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9459,8 +10214,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9471,8 +10227,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9483,8 +10240,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9495,8 +10253,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9526,8 +10285,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9538,8 +10298,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9550,8 +10311,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9562,8 +10324,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9574,8 +10338,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9586,8 +10351,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9598,8 +10364,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9629,8 +10396,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9678,8 +10446,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9690,8 +10459,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9702,8 +10472,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9714,8 +10485,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9726,8 +10499,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9738,8 +10513,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9750,8 +10526,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9762,8 +10539,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9773,9 +10551,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9786,8 +10565,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9798,8 +10579,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9810,8 +10593,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9822,8 +10607,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9834,8 +10620,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9865,8 +10652,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9877,8 +10665,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9889,8 +10678,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9901,8 +10691,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9913,8 +10705,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9925,8 +10718,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9937,8 +10731,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "min_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9949,8 +10744,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9961,8 +10757,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9973,8 +10770,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9985,8 +10783,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10016,8 +10815,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10028,8 +10828,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10040,8 +10841,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10052,8 +10854,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enforce_unique",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10064,8 +10867,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "export_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10076,8 +10880,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10088,8 +10894,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "import_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10100,8 +10907,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10112,8 +10920,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10124,8 +10933,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "rd",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10136,8 +10946,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10239,8 +11050,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10270,8 +11082,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10301,8 +11114,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10332,8 +11146,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10363,8 +11178,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10394,8 +11210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10425,8 +11242,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10456,8 +11274,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10559,8 +11378,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10571,8 +11391,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10583,8 +11404,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10595,8 +11417,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10607,8 +11430,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10619,8 +11444,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10631,8 +11458,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10643,8 +11471,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10655,8 +11484,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10686,8 +11516,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10698,8 +11529,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10710,8 +11542,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10722,8 +11555,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10734,8 +11569,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10746,8 +11582,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10758,8 +11596,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10770,8 +11610,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10782,8 +11623,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10794,8 +11636,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -10806,8 +11650,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10818,8 +11663,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -10849,8 +11696,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10898,8 +11746,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10929,8 +11778,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10978,8 +11828,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10990,8 +11841,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11002,8 +11854,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11014,8 +11867,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11026,8 +11881,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11038,8 +11895,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11050,8 +11908,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11062,8 +11921,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11073,9 +11933,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11086,8 +11947,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11098,8 +11961,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11110,8 +11974,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11122,8 +11987,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11153,8 +12020,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11165,8 +12033,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11177,8 +12046,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11189,8 +12059,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11201,8 +12073,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11213,8 +12086,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11225,8 +12099,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11256,8 +12131,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11268,8 +12144,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11280,8 +12157,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11292,8 +12170,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11304,8 +12184,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11316,8 +12197,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11328,8 +12210,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11359,8 +12242,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11371,8 +12255,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11383,8 +12268,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11395,8 +12281,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11407,8 +12294,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11419,8 +12307,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11431,8 +12320,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11443,8 +12333,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11455,8 +12347,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11467,8 +12360,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11479,8 +12373,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11491,8 +12386,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11503,8 +12399,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11515,8 +12412,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11527,8 +12425,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11539,8 +12438,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11551,8 +12452,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11563,8 +12465,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11575,8 +12479,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11587,8 +12492,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11618,8 +12524,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11630,8 +12537,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11642,8 +12550,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11654,8 +12563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11666,8 +12576,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11678,8 +12589,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -11690,8 +12602,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11702,8 +12616,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11714,8 +12629,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11726,8 +12642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11738,8 +12655,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11750,8 +12668,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11762,8 +12681,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11774,8 +12695,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11786,8 +12708,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11798,8 +12721,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11810,8 +12734,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11822,8 +12747,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.3/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.3/summary.txt
@@ -120,51 +120,15 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
 dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
-dcim.inventoryitemrole => dcim.inventoryitemrole | Disabled with reason: Nautobot content type: `dcim.inventoryitemrole` not found
-dcim.inventoryitemtemplate => dcim.inventoryitemtemplate | Disabled with reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-dcim.module => dcim.module | Disabled with reason: Nautobot content type: `dcim.module` not found
-dcim.modulebay => dcim.modulebay | Disabled with reason: Nautobot content type: `dcim.modulebay` not found
-dcim.modulebaytemplate => dcim.modulebaytemplate | Disabled with reason: Nautobot content type: `dcim.modulebaytemplate` not found
-dcim.moduletype => dcim.moduletype | Disabled with reason: Nautobot content type: `dcim.moduletype` not found
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
 ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
-ipam.l2vpn => ipam.l2vpn | Disabled with reason: Nautobot content type: `ipam.l2vpn` not found
-ipam.l2vpntermination => ipam.l2vpntermination | Disabled with reason: Nautobot content type: `ipam.l2vpntermination` not found
 ipam.role => extras.role
-ipam.servicetemplate => ipam.servicetemplate | Disabled with reason: Nautobot content type: `ipam.servicetemplate` not found
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
@@ -172,960 +136,782 @@ dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
 dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_date (DATA) => NO IMPORTER => NO TARGET
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_date => NO IMPORTER => NO TARGET
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-account (DATA) => value_importer => account (CharField)
-admin_contact (DATA) => value_importer => admin_contact (TextField)
-asn (DATA) => integer_importer => asn (BigIntegerField)
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-noc_contact (DATA) => value_importer => noc_contact (TextField)
-portal_url (DATA) => value_importer => portal_url (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+account => value_importer => account (CharField)
+admin_contact => value_importer => admin_contact (TextField)
+asn => integer_importer => asn (BigIntegerField)
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+noc_contact => value_importer => noc_contact (TextField)
+portal_url => value_importer => portal_url (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-service_id (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
+service_id => NO IMPORTER => NO TARGET
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
+_abs_length => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+tenant => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.cabletermination => dcim.cable **************************************************************
-_device (DATA) => NO IMPORTER => NO TARGET
-_location (DATA) => NO IMPORTER => NO TARGET
-_rack (DATA) => NO IMPORTER => NO TARGET
-_site (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
+_device => NO IMPORTER => NO TARGET
+_location => NO IMPORTER => NO TARGET
+_rack => NO IMPORTER => NO TARGET
+_site => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-device_role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+device_role => relation_importer => role_id (RoleField)
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
 * dcim.frontport => dcim.frontport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-duplex (DATA) => NO IMPORTER => NO TARGET
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-module (DATA) => NO IMPORTER => NO TARGET
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-rf_channel (DATA) => NO IMPORTER => NO TARGET
-rf_channel_frequency (DATA) => NO IMPORTER => NO TARGET
-rf_channel_width (DATA) => NO IMPORTER => NO TARGET
-rf_role (DATA) => NO IMPORTER => NO TARGET
-speed (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-tx_power (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-wireless_lans (DATA) => NO IMPORTER => NO TARGET
-wireless_link (DATA) => NO IMPORTER => NO TARGET
-wwn (DATA) => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+duplex => NO IMPORTER => NO TARGET
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+module => NO IMPORTER => NO TARGET
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+rf_channel => NO IMPORTER => NO TARGET
+rf_channel_frequency => NO IMPORTER => NO TARGET
+rf_channel_width => NO IMPORTER => NO TARGET
+rf_role => NO IMPORTER => NO TARGET
+speed => NO IMPORTER => NO TARGET
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+tx_power => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
+wireless_lans => NO IMPORTER => NO TARGET
+wireless_link => NO IMPORTER => NO TARGET
+wwn => NO IMPORTER => NO TARGET
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.inventoryitemrole => dcim.inventoryitemrole *************************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemrole` not found
-* dcim.inventoryitemtemplate => dcim.inventoryitemtemplate *****************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-* dcim.module => dcim.module ***********************************************************************
-    Disable reason: Nautobot content type: `dcim.module` not found
-* dcim.modulebay => dcim.modulebay *****************************************************************
-    Disable reason: Nautobot content type: `dcim.modulebay` not found
-* dcim.modulebaytemplate => dcim.modulebaytemplate *************************************************
-    Disable reason: Nautobot content type: `dcim.modulebaytemplate` not found
-* dcim.moduletype => dcim.moduletype ***************************************************************
-    Disable reason: Nautobot content type: `dcim.moduletype` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-napalm_args (DATA) => json_importer => napalm_args (JSONField)
-napalm_driver (DATA) => value_importer => napalm_driver (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+napalm_args => json_importer => napalm_args (JSONField)
+napalm_driver => value_importer => napalm_driver (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackreservation => dcim.rackreservation *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-units (DATA) (CUSTOM) => units_importer => units (JSONField)
-user (DATA) => relation_importer => user_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+rack => relation_importer => rack_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+units => units_importer => units (JSONField)
+user => relation_importer => user_id (ForeignKey)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (DATA) (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => constant_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.virtualchassis => dcim.virtualchassis *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-domain (DATA) => value_importer => domain (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-master (DATA) => relation_importer => master_id (OneToOneField)
-name (DATA) => value_importer => name (CharField)
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+domain => value_importer => domain (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+master => relation_importer => master_id (OneToOneField)
+name => value_importer => name (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (CUSTOM) => choices_importer => Custom Target
-choices (DATA) (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-group_name (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-object_type (DATA) => NO IMPORTER => NO TARGET
-required (DATA) => value_importer => required (BooleanField)
-type (DATA) => value_importer => type (CharField)
-ui_visibility (DATA) => NO IMPORTER => NO TARGET
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
+choices => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+group_name => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+object_type => NO IMPORTER => NO TARGET
+required => value_importer => required (BooleanField)
+type => value_importer => type (CharField)
+ui_visibility => NO IMPORTER => NO TARGET
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.tag => extras.tag *************************************************************************
-color (DATA) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (DATA) => tagged_object_importer => content_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (DATA) (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (DATA) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+content_type => tagged_object_importer => content_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_id => tagged_object_importer => object_id (UUIDField)
+tag => tagged_object_importer => tag_id (ForeignKey)
 * ipam.aggregate => ipam.prefix ********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.ipaddress => ipam.ipaddress *****************************************************************
-address (DATA) => value_importer => address (Property)
-assigned_object_id (DATA) => NO IMPORTER => NO TARGET
-assigned_object_type (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-dns_name (DATA) => value_importer => dns_name (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-nat_inside (DATA) => relation_importer => nat_inside_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
-* ipam.l2vpn => ipam.l2vpn *************************************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpn` not found
-* ipam.l2vpntermination => ipam.l2vpntermination ***************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpntermination` not found
+address => value_importer => address (Property)
+assigned_object_id => NO IMPORTER => NO TARGET
+assigned_object_type => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+dns_name => value_importer => dns_name (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+nat_inside => relation_importer => nat_inside_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.routetarget => ipam.routetarget *************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.servicetemplate => ipam.servicetemplate *****************************************************
-    Disable reason: Nautobot content type: `ipam.servicetemplate` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.vlan => ipam.vlan ***************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-max_vid (DATA) => NO IMPORTER => NO TARGET
-min_vid (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+max_vid => NO IMPORTER => NO TARGET
+min_vid => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * ipam.vrf => ipam.vrf *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enforce_unique (DATA) => NO IMPORTER => NO TARGET
-export_targets (DATA) => uuids_importer => export_targets (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-import_targets (DATA) => uuids_importer => import_targets (ManyToManyField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rd (DATA) => value_importer => rd (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enforce_unique => NO IMPORTER => NO TARGET
+export_targets => uuids_importer => export_targets (ManyToManyField)
+id => uid_from_data => id (UUIDField)
+import_targets => uuids_importer => import_targets (ManyToManyField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rd => value_importer => rd (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => NO IMPORTER => NO TARGET
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+status => NO IMPORTER => NO TARGET
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-device (DATA) => NO IMPORTER => NO TARGET
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+device => NO IMPORTER => NO TARGET
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+site => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+_name => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.4/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.4/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -88,8 +91,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -119,8 +124,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -152,8 +158,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +171,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +197,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -212,8 +223,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -224,8 +236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -248,8 +262,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -260,8 +276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -284,8 +303,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -296,8 +317,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -327,8 +349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +362,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +375,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +388,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +441,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -423,8 +454,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -435,8 +467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,8 +480,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -459,8 +494,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -471,8 +507,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +521,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "termination_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -495,8 +534,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -507,8 +548,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -538,8 +581,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -550,8 +594,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +607,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +620,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +633,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -610,8 +659,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -622,8 +673,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -634,8 +686,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -646,8 +699,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +712,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -670,8 +725,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -682,8 +738,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -693,9 +750,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -706,8 +764,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +778,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -730,8 +791,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -742,8 +804,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -773,8 +836,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -785,8 +849,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -809,8 +875,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -821,8 +889,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -833,8 +902,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -845,8 +915,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -876,8 +947,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -888,8 +960,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +973,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +986,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +999,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -948,8 +1025,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -960,8 +1039,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -972,8 +1052,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -984,8 +1065,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1015,8 +1097,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1027,8 +1110,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1039,8 +1123,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1149,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1163,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1087,8 +1176,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1189,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1111,8 +1202,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "service_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1145,8 +1237,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1157,8 +1251,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1169,8 +1264,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1200,8 +1296,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1212,8 +1309,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1224,8 +1322,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1236,8 +1335,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1361,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1388,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1296,8 +1401,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1308,8 +1414,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1320,8 +1427,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1332,8 +1440,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1344,8 +1454,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1356,8 +1467,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1387,8 +1499,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1418,8 +1531,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1430,8 +1544,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_location",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1442,8 +1557,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1454,8 +1570,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1466,8 +1583,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1478,8 +1597,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1490,8 +1610,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1502,8 +1623,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1514,8 +1636,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1545,8 +1668,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1557,8 +1681,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1694,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1707,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1720,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1733,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1617,8 +1746,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1759,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1641,8 +1772,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1786,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1665,8 +1799,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1677,8 +1812,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1689,8 +1825,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1701,8 +1838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1713,8 +1851,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1725,8 +1864,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1756,8 +1896,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1768,8 +1909,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1922,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1792,8 +1935,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1804,8 +1948,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1816,8 +1962,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1828,8 +1975,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1840,8 +1988,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1852,8 +2001,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1864,8 +2014,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1895,8 +2046,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1926,8 +2078,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1957,8 +2110,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1969,8 +2123,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2149,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2005,8 +2162,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2175,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2188,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2041,8 +2201,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2053,8 +2214,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2228,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2077,8 +2241,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2089,8 +2254,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2101,8 +2268,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2113,8 +2281,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2294,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2137,8 +2308,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2321,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2161,8 +2334,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2347,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2185,8 +2360,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2197,8 +2373,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2208,9 +2385,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2221,8 +2399,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2233,8 +2412,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2245,8 +2425,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2257,8 +2439,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2269,8 +2453,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2281,8 +2466,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2293,8 +2479,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2305,8 +2492,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2336,8 +2524,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2348,8 +2537,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2360,8 +2550,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2372,8 +2563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2384,8 +2576,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2396,8 +2589,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2408,8 +2603,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2420,8 +2616,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2432,8 +2629,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2444,8 +2642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2475,8 +2674,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2487,8 +2687,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2499,8 +2700,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2511,8 +2713,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2523,8 +2726,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2535,8 +2740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2547,8 +2753,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2559,8 +2766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2590,8 +2798,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2602,8 +2812,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2614,8 +2825,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2626,8 +2838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2638,8 +2851,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2650,8 +2864,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2662,8 +2878,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2674,8 +2891,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2686,8 +2904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2698,8 +2917,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2729,8 +2949,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2741,20 +2962,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2765,8 +2975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2777,8 +2988,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2789,8 +3001,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2801,8 +3014,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2813,8 +3027,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2825,8 +3041,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2837,8 +3056,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2849,8 +3069,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2861,8 +3082,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2873,8 +3096,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2885,8 +3110,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2897,8 +3123,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2909,8 +3137,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2921,8 +3150,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2933,8 +3163,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -2945,8 +3176,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2957,8 +3189,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2988,8 +3221,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3000,8 +3234,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3012,8 +3247,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3024,8 +3260,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3036,8 +3273,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3048,8 +3286,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3060,8 +3299,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3072,8 +3312,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3084,8 +3325,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3096,8 +3339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3108,8 +3352,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3120,8 +3365,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3132,8 +3378,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3144,8 +3391,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3156,8 +3404,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3168,8 +3417,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3180,8 +3430,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3211,8 +3462,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3223,8 +3475,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3235,8 +3488,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3247,8 +3501,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3259,8 +3514,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3271,8 +3527,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3283,8 +3541,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3295,8 +3554,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3307,8 +3567,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3319,8 +3580,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3331,8 +3593,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3343,8 +3607,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3355,8 +3620,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3386,8 +3652,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3665,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3678,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3422,8 +3691,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3434,8 +3704,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3446,8 +3717,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3458,8 +3730,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3470,8 +3743,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3482,8 +3756,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3494,8 +3769,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "duplex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3506,8 +3782,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3518,8 +3795,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3530,8 +3809,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3542,8 +3822,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3554,8 +3835,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3566,8 +3848,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3578,8 +3861,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3590,8 +3874,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3602,8 +3887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3614,8 +3900,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3626,8 +3913,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3638,8 +3926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3650,8 +3939,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3662,8 +3953,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3674,8 +3966,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3686,8 +3979,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3698,8 +3992,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_frequency",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3710,8 +4005,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3722,8 +4018,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3734,8 +4031,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3746,8 +4044,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3758,8 +4057,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3770,8 +4070,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tx_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3782,8 +4083,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3794,8 +4096,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3806,8 +4109,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vdcs",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3818,8 +4122,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3830,8 +4135,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_lans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3842,8 +4148,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_link",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3854,8 +4161,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wwn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3885,8 +4193,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3897,8 +4206,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3909,8 +4219,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3921,8 +4232,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3933,8 +4245,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3945,8 +4259,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3957,8 +4272,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3969,8 +4285,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3981,8 +4298,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3993,8 +4311,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4005,8 +4324,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4017,8 +4337,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4029,8 +4350,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4060,8 +4382,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4072,8 +4395,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4084,8 +4408,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4096,8 +4421,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4108,8 +4434,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4175,8 +4502,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4187,8 +4515,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4199,8 +4528,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4211,8 +4541,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4223,8 +4555,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4235,8 +4568,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4247,8 +4582,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4259,8 +4596,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4271,8 +4609,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4283,8 +4622,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4295,8 +4636,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4307,8 +4650,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4319,8 +4664,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4331,8 +4677,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4343,8 +4691,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4355,8 +4704,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4386,8 +4737,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4398,8 +4750,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4410,8 +4764,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4422,8 +4777,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4434,8 +4790,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4446,8 +4803,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4458,8 +4816,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4470,8 +4829,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4482,8 +4842,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4513,8 +4874,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4525,8 +4887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4537,8 +4900,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4549,8 +4913,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4561,8 +4928,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4573,8 +4941,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4585,8 +4955,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4688,8 +5059,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4700,8 +5072,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4712,8 +5085,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4724,8 +5098,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4736,8 +5112,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4748,8 +5125,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4760,8 +5138,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4772,8 +5151,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "napalm_args",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4784,8 +5164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "napalm_driver",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4796,8 +5177,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4827,8 +5209,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4839,8 +5222,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4851,8 +5235,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4863,8 +5248,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4875,8 +5261,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4887,8 +5274,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4899,8 +5287,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4911,8 +5300,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4923,8 +5313,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4935,8 +5326,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4947,8 +5340,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4959,8 +5353,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4971,8 +5366,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -4983,8 +5379,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4995,8 +5392,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -5007,8 +5405,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5019,8 +5418,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5031,8 +5431,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -5043,8 +5445,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -5055,8 +5458,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -5067,8 +5471,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -5098,8 +5503,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5110,8 +5516,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5122,8 +5529,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5134,8 +5542,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5146,8 +5555,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5158,8 +5568,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5170,8 +5581,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5182,8 +5594,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5194,8 +5607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5206,8 +5620,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5218,8 +5634,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5230,8 +5647,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5242,8 +5660,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5254,8 +5673,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5266,8 +5686,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5278,8 +5699,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5290,8 +5712,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5321,8 +5744,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5333,8 +5757,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5345,8 +5770,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5357,8 +5783,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5369,8 +5796,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5381,8 +5809,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5393,8 +5823,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5405,8 +5836,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5417,8 +5849,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5429,8 +5862,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5441,8 +5875,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5453,8 +5889,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5484,8 +5921,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5496,8 +5934,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5508,8 +5947,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5520,8 +5960,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5532,8 +5973,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5544,8 +5987,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5556,8 +6000,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5568,8 +6014,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5579,9 +6026,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5592,8 +6040,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5623,8 +6073,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5635,8 +6086,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5647,8 +6099,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5659,8 +6112,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5671,8 +6125,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5683,8 +6138,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5695,8 +6151,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5707,8 +6164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5719,8 +6177,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5731,8 +6190,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5743,8 +6204,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5755,8 +6217,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5767,8 +6230,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5779,8 +6243,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5791,8 +6256,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5803,8 +6269,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5815,8 +6282,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5846,8 +6314,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5858,8 +6327,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5870,8 +6340,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5882,8 +6353,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5894,8 +6366,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5906,8 +6379,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5918,8 +6393,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5930,8 +6406,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5942,8 +6419,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5954,8 +6432,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5966,8 +6445,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5978,8 +6458,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6009,8 +6490,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_max_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6021,8 +6503,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6033,8 +6516,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6045,8 +6529,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6057,8 +6542,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6069,8 +6555,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6081,8 +6568,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6093,8 +6581,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -6105,8 +6594,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6117,8 +6607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6129,8 +6620,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6141,8 +6634,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6153,8 +6647,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6165,8 +6661,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6177,8 +6674,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mounting_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6189,8 +6687,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6201,8 +6700,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6213,8 +6713,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6225,8 +6726,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6236,9 +6738,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6249,8 +6752,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6261,8 +6766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6273,8 +6779,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6285,8 +6793,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6297,8 +6807,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6309,8 +6820,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6321,8 +6833,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -6333,8 +6846,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6345,8 +6859,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6357,8 +6872,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -6388,8 +6904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6400,8 +6917,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6412,8 +6930,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6424,8 +6943,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6436,8 +6956,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6448,8 +6970,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6460,8 +6983,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6472,8 +6996,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6484,8 +7009,10 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6496,8 +7023,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6527,8 +7055,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -6539,8 +7069,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6551,8 +7082,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6563,8 +7095,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6575,8 +7108,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6587,8 +7121,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6599,8 +7135,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6611,8 +7148,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6623,8 +7161,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6654,8 +7193,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6666,8 +7206,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6678,8 +7219,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6690,8 +7232,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6702,8 +7245,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6714,8 +7258,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6726,8 +7271,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6738,8 +7284,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6750,8 +7297,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6762,8 +7311,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6774,8 +7324,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6786,8 +7337,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6798,8 +7350,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6810,8 +7363,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6822,8 +7376,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6834,8 +7389,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6865,8 +7421,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6877,8 +7434,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6889,8 +7447,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6901,8 +7460,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6913,8 +7473,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6925,8 +7486,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6937,8 +7500,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6949,8 +7513,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6961,8 +7526,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6973,8 +7539,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6985,8 +7552,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6997,8 +7565,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7028,8 +7597,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7040,8 +7610,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7052,8 +7623,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7064,8 +7636,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7076,8 +7650,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7088,8 +7663,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7100,8 +7677,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7112,8 +7691,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7124,8 +7704,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7136,8 +7717,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7148,8 +7730,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7160,8 +7744,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7172,8 +7757,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7184,8 +7770,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7215,8 +7803,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7227,8 +7816,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7239,8 +7829,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7251,8 +7842,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7263,8 +7855,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7275,8 +7868,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7287,8 +7881,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7299,8 +7894,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7311,8 +7908,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7323,8 +7922,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7335,8 +7935,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7347,8 +7948,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7359,8 +7961,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7371,8 +7974,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7383,8 +7987,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7395,8 +8000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7407,8 +8013,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7419,8 +8027,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7431,8 +8040,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7443,8 +8053,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7455,8 +8066,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7467,8 +8080,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7479,8 +8093,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7491,8 +8106,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7522,8 +8138,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7534,8 +8151,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7546,8 +8164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7558,8 +8177,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7570,8 +8190,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7582,8 +8204,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7594,8 +8217,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7606,8 +8231,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7618,8 +8245,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7630,8 +8258,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7642,8 +8271,10 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7654,8 +8285,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7666,8 +8299,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7678,8 +8312,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7709,8 +8345,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7721,8 +8358,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7733,8 +8371,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7745,8 +8384,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7757,8 +8397,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "domain",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7769,8 +8410,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7781,8 +8424,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7793,8 +8437,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "master",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7805,8 +8450,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7908,8 +8554,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7957,8 +8604,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7969,8 +8617,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7981,8 +8631,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7993,8 +8645,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8005,8 +8658,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8017,8 +8671,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8029,8 +8684,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -8041,8 +8697,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "group_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8053,8 +8710,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8065,8 +8724,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8077,8 +8737,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8089,8 +8750,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8101,8 +8764,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8113,8 +8777,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -8125,8 +8790,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "search_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8137,8 +8803,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -8149,8 +8816,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "ui_visibility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8161,8 +8829,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8173,8 +8842,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8185,8 +8855,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8197,8 +8868,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -8228,8 +8900,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8240,8 +8913,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8252,8 +8926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8301,8 +8976,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8332,8 +9008,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8363,8 +9040,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8394,8 +9072,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8425,8 +9104,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8456,8 +9136,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8468,8 +9149,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8480,8 +9162,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8529,8 +9212,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8541,8 +9225,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8628,8 +9313,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8640,8 +9326,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8652,8 +9339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8683,8 +9371,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8695,8 +9384,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8707,8 +9397,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8719,8 +9410,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8731,8 +9423,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8743,8 +9437,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8755,8 +9450,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8767,8 +9463,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8798,8 +9495,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8810,8 +9509,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8822,8 +9523,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8834,8 +9537,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8865,8 +9570,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8896,8 +9602,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8908,8 +9615,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8920,8 +9628,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8932,8 +9641,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8944,8 +9654,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8956,8 +9667,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8968,8 +9681,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8980,8 +9694,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8992,8 +9707,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9004,8 +9720,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9016,8 +9733,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9065,8 +9783,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9077,8 +9796,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -9126,8 +9846,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9138,8 +9859,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9150,8 +9872,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9162,8 +9885,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9174,8 +9898,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9186,8 +9911,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9198,8 +9924,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9210,8 +9937,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "dns_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9222,8 +9950,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9234,8 +9964,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9246,8 +9977,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "nat_inside",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9258,8 +9990,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9270,8 +10004,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9282,8 +10018,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9294,8 +10031,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9379,8 +10117,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9391,8 +10130,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9403,8 +10143,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9415,8 +10156,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9427,8 +10169,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9439,8 +10182,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9451,8 +10195,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9463,8 +10209,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9475,8 +10222,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9487,8 +10235,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9499,8 +10248,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9511,8 +10261,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9522,9 +10273,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9535,8 +10287,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9547,8 +10301,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9559,8 +10315,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9571,8 +10329,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9583,8 +10342,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9595,8 +10355,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9626,8 +10387,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9638,8 +10400,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9650,8 +10413,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9662,8 +10426,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9674,8 +10440,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -9686,8 +10453,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9698,8 +10466,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9710,8 +10479,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9741,8 +10511,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -9753,8 +10524,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9765,8 +10537,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9777,8 +10550,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9789,8 +10563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9801,8 +10576,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9813,8 +10590,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9825,8 +10603,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9837,8 +10616,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9849,8 +10629,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9880,8 +10661,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9892,8 +10674,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9904,8 +10687,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9916,8 +10700,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9928,8 +10713,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9940,8 +10727,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9952,8 +10740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9964,8 +10753,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9995,8 +10785,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10044,8 +10835,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10056,8 +10848,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10068,8 +10861,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10080,8 +10874,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10092,8 +10887,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10104,8 +10901,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10116,8 +10915,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10128,8 +10928,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10140,8 +10941,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10151,9 +10953,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10164,8 +10967,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10176,8 +10981,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10188,8 +10995,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -10200,8 +11009,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10212,8 +11022,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10243,8 +11054,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10255,8 +11067,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10267,8 +11080,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10279,8 +11093,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10291,8 +11107,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10303,8 +11120,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10315,8 +11133,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "min_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10327,8 +11146,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10339,8 +11159,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10351,8 +11172,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10363,8 +11185,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10394,8 +11217,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10406,8 +11230,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10418,8 +11243,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10430,8 +11256,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10442,8 +11269,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enforce_unique",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10454,8 +11282,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "export_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10466,8 +11295,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10478,8 +11309,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "import_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10490,8 +11322,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10502,8 +11335,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10514,8 +11348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "rd",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10526,8 +11361,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10629,8 +11465,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10660,8 +11497,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10691,8 +11529,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10722,8 +11561,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10753,8 +11593,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10784,8 +11625,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10815,8 +11657,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10846,8 +11689,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10949,8 +11793,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10961,8 +11806,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10973,8 +11819,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10985,8 +11832,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10997,8 +11845,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11009,8 +11859,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11021,8 +11873,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11033,8 +11886,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11045,8 +11899,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11076,8 +11931,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11088,8 +11944,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11100,8 +11957,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11112,8 +11970,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11124,8 +11984,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11136,8 +11997,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11148,8 +12011,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11160,8 +12025,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11172,8 +12038,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11184,8 +12051,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11196,8 +12065,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11208,8 +12078,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -11239,8 +12111,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11288,8 +12161,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11319,8 +12193,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11368,8 +12243,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11380,8 +12256,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11392,8 +12269,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11404,8 +12282,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11416,8 +12295,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11428,8 +12309,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11440,8 +12323,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11452,8 +12336,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11464,8 +12349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11475,9 +12361,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11488,8 +12375,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11500,8 +12389,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11512,8 +12402,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11524,8 +12415,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11555,8 +12448,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11567,8 +12461,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11579,8 +12474,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11591,8 +12487,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11603,8 +12501,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11615,8 +12514,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11627,8 +12527,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11658,8 +12559,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11670,8 +12572,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11682,8 +12585,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11694,8 +12598,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11706,8 +12612,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11718,8 +12625,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11730,8 +12638,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11761,8 +12670,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11773,8 +12683,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11785,8 +12696,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11797,8 +12709,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11809,8 +12722,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11821,8 +12735,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11833,8 +12748,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11845,8 +12761,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11857,8 +12774,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11869,8 +12788,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11881,8 +12801,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11893,8 +12814,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11905,8 +12827,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11917,8 +12840,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11929,8 +12853,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11941,8 +12866,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11953,8 +12879,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11965,8 +12893,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11977,8 +12906,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11989,8 +12920,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12001,8 +12933,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -12032,8 +12965,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12044,8 +12978,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12056,8 +12991,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12068,8 +13004,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12080,8 +13017,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12092,8 +13030,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -12104,8 +13043,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12116,8 +13057,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -12128,8 +13070,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12140,8 +13083,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12152,8 +13096,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12164,8 +13109,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12176,8 +13122,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12188,8 +13136,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -12200,8 +13149,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12212,8 +13162,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12224,8 +13175,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12236,8 +13188,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.4/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.4/summary.txt
@@ -120,56 +120,15 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
 dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
-dcim.inventoryitemrole => dcim.inventoryitemrole | Disabled with reason: Nautobot content type: `dcim.inventoryitemrole` not found
-dcim.inventoryitemtemplate => dcim.inventoryitemtemplate | Disabled with reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-dcim.module => dcim.module | Disabled with reason: Nautobot content type: `dcim.module` not found
-dcim.modulebay => dcim.modulebay | Disabled with reason: Nautobot content type: `dcim.modulebay` not found
-dcim.modulebaytemplate => dcim.modulebaytemplate | Disabled with reason: Nautobot content type: `dcim.modulebaytemplate` not found
-dcim.moduletype => dcim.moduletype | Disabled with reason: Nautobot content type: `dcim.moduletype` not found
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
-dcim.virtualdevicecontext => dcim.virtualdevicecontext | Disabled with reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
-extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
-extras.stagedchange => extras.stagedchange | Disabled with reason: Nautobot content type: `extras.stagedchange` not found
 ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
-ipam.l2vpn => ipam.l2vpn | Disabled with reason: Nautobot content type: `ipam.l2vpn` not found
-ipam.l2vpntermination => ipam.l2vpntermination | Disabled with reason: Nautobot content type: `ipam.l2vpntermination` not found
 ipam.role => extras.role
-ipam.servicetemplate => ipam.servicetemplate | Disabled with reason: Nautobot content type: `ipam.servicetemplate` not found
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
@@ -177,997 +136,809 @@ dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
 dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_date (DATA) => NO IMPORTER => NO TARGET
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_date => NO IMPORTER => NO TARGET
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-account (DATA) => value_importer => account (CharField)
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+account => value_importer => account (CharField)
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-service_id (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
+service_id => NO IMPORTER => NO TARGET
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
+_abs_length => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+tenant => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.cabletermination => dcim.cable **************************************************************
-_device (DATA) => NO IMPORTER => NO TARGET
-_location (DATA) => NO IMPORTER => NO TARGET
-_rack (DATA) => NO IMPORTER => NO TARGET
-_site (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
+_device => NO IMPORTER => NO TARGET
+_location => NO IMPORTER => NO TARGET
+_rack => NO IMPORTER => NO TARGET
+_site => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device_role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device_role => relation_importer => role_id (RoleField)
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
+_abs_weight => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
 * dcim.frontport => dcim.frontport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-duplex (DATA) => NO IMPORTER => NO TARGET
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-module (DATA) => NO IMPORTER => NO TARGET
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-rf_channel (DATA) => NO IMPORTER => NO TARGET
-rf_channel_frequency (DATA) => NO IMPORTER => NO TARGET
-rf_channel_width (DATA) => NO IMPORTER => NO TARGET
-rf_role (DATA) => NO IMPORTER => NO TARGET
-speed (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-tx_power (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-vdcs (DATA) => NO IMPORTER => NO TARGET
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-wireless_lans (DATA) => NO IMPORTER => NO TARGET
-wireless_link (DATA) => NO IMPORTER => NO TARGET
-wwn (DATA) => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+duplex => NO IMPORTER => NO TARGET
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+module => NO IMPORTER => NO TARGET
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+rf_channel => NO IMPORTER => NO TARGET
+rf_channel_frequency => NO IMPORTER => NO TARGET
+rf_channel_width => NO IMPORTER => NO TARGET
+rf_role => NO IMPORTER => NO TARGET
+speed => NO IMPORTER => NO TARGET
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+tx_power => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+vdcs => NO IMPORTER => NO TARGET
+vrf => relation_importer => vrf_id (ForeignKey)
+wireless_lans => NO IMPORTER => NO TARGET
+wireless_link => NO IMPORTER => NO TARGET
+wwn => NO IMPORTER => NO TARGET
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.inventoryitemrole => dcim.inventoryitemrole *************************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemrole` not found
-* dcim.inventoryitemtemplate => dcim.inventoryitemtemplate *****************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-* dcim.module => dcim.module ***********************************************************************
-    Disable reason: Nautobot content type: `dcim.module` not found
-* dcim.modulebay => dcim.modulebay *****************************************************************
-    Disable reason: Nautobot content type: `dcim.modulebay` not found
-* dcim.modulebaytemplate => dcim.modulebaytemplate *************************************************
-    Disable reason: Nautobot content type: `dcim.modulebaytemplate` not found
-* dcim.moduletype => dcim.moduletype ***************************************************************
-    Disable reason: Nautobot content type: `dcim.moduletype` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-napalm_args (DATA) => json_importer => napalm_args (JSONField)
-napalm_driver (DATA) => value_importer => napalm_driver (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+napalm_args => json_importer => napalm_args (JSONField)
+napalm_driver => value_importer => napalm_driver (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_abs_max_weight (DATA) => NO IMPORTER => NO TARGET
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-description (DATA) => NO IMPORTER => NO TARGET
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-max_weight (DATA) => NO IMPORTER => NO TARGET
-mounting_depth (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
+_abs_max_weight => NO IMPORTER => NO TARGET
+_abs_weight => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+description => NO IMPORTER => NO TARGET
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+max_weight => NO IMPORTER => NO TARGET
+mounting_depth => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackreservation => dcim.rackreservation *****************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-units (DATA) (CUSTOM) => units_importer => units (JSONField)
-user (DATA) => relation_importer => user_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+rack => relation_importer => rack_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+units => units_importer => units (JSONField)
+user => relation_importer => user_id (ForeignKey)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (DATA) (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => constant_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.virtualchassis => dcim.virtualchassis *******************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-domain (DATA) => value_importer => domain (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-master (DATA) => relation_importer => master_id (OneToOneField)
-name (DATA) => value_importer => name (CharField)
-* dcim.virtualdevicecontext => dcim.virtualdevicecontext *******************************************
-    Disable reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.branch => extras.branch *******************************************************************
-    Disable reason: Nautobot content type: `extras.branch` not found
-* extras.cachedvalue => extras.cachedvalue *********************************************************
-    Disable reason: Nautobot content type: `extras.cachedvalue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+domain => value_importer => domain (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+master => relation_importer => master_id (OneToOneField)
+name => value_importer => name (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (CUSTOM) => choices_importer => Custom Target
-choices (DATA) (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-group_name (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-object_type (DATA) => NO IMPORTER => NO TARGET
-required (DATA) => value_importer => required (BooleanField)
-search_weight (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-ui_visibility (DATA) => NO IMPORTER => NO TARGET
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.savedfilter => extras.savedfilter *********************************************************
-    Disable reason: Nautobot content type: `extras.savedfilter` not found
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.stagedchange => extras.stagedchange *******************************************************
-    Disable reason: Nautobot content type: `extras.stagedchange` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
+choices => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+group_name => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+object_type => NO IMPORTER => NO TARGET
+required => value_importer => required (BooleanField)
+search_weight => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+ui_visibility => NO IMPORTER => NO TARGET
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.tag => extras.tag *************************************************************************
-color (DATA) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (DATA) => tagged_object_importer => content_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (DATA) (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (DATA) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+content_type => tagged_object_importer => content_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_id => tagged_object_importer => object_id (UUIDField)
+tag => tagged_object_importer => tag_id (ForeignKey)
 * ipam.aggregate => ipam.prefix ********************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.ipaddress => ipam.ipaddress *****************************************************************
-address (DATA) => value_importer => address (Property)
-assigned_object_id (DATA) => NO IMPORTER => NO TARGET
-assigned_object_type (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-dns_name (DATA) => value_importer => dns_name (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-nat_inside (DATA) => relation_importer => nat_inside_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
-* ipam.l2vpn => ipam.l2vpn *************************************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpn` not found
-* ipam.l2vpntermination => ipam.l2vpntermination ***************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpntermination` not found
+address => value_importer => address (Property)
+assigned_object_id => NO IMPORTER => NO TARGET
+assigned_object_type => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+dns_name => value_importer => dns_name (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+nat_inside => relation_importer => nat_inside_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.routetarget => ipam.routetarget *************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.servicetemplate => ipam.servicetemplate *****************************************************
-    Disable reason: Nautobot content type: `ipam.servicetemplate` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.vlan => ipam.vlan ***************************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-max_vid (DATA) => NO IMPORTER => NO TARGET
-min_vid (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+max_vid => NO IMPORTER => NO TARGET
+min_vid => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * ipam.vrf => ipam.vrf *****************************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enforce_unique (DATA) => NO IMPORTER => NO TARGET
-export_targets (DATA) => uuids_importer => export_targets (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-import_targets (DATA) => uuids_importer => import_targets (ManyToManyField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rd (DATA) => value_importer => rd (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enforce_unique => NO IMPORTER => NO TARGET
+export_targets => uuids_importer => export_targets (ManyToManyField)
+id => uid_from_data => id (UUIDField)
+import_targets => uuids_importer => import_targets (ManyToManyField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rd => value_importer => rd (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => NO IMPORTER => NO TARGET
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+status => NO IMPORTER => NO TARGET
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device (DATA) => NO IMPORTER => NO TARGET
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device => NO IMPORTER => NO TARGET
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+site => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+_name => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.5/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.5/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -88,8 +91,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -119,8 +124,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -152,8 +158,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +171,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +197,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -212,8 +223,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -224,8 +236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -248,8 +262,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -260,8 +276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -284,8 +303,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -296,8 +317,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -327,8 +349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +362,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +375,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +388,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +441,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -423,8 +454,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -435,8 +467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,8 +480,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "provider_account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -459,8 +493,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -471,8 +507,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +520,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -495,8 +534,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "termination_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -507,8 +547,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -519,8 +561,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -550,8 +594,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +607,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +620,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +633,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -610,8 +659,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -622,8 +672,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -634,8 +686,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -646,8 +699,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +712,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -670,8 +725,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -682,8 +738,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -694,8 +751,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -705,9 +763,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +777,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -730,8 +791,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -742,8 +804,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -754,8 +817,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -785,8 +849,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -809,8 +875,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -821,8 +888,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -833,8 +902,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -845,8 +915,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -857,8 +928,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -888,8 +960,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +973,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +986,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +999,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -948,8 +1025,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -960,8 +1039,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -972,8 +1052,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -984,8 +1065,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1015,8 +1097,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1027,8 +1110,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1039,8 +1123,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1149,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1163,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1087,8 +1176,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1189,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1111,8 +1202,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "service_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1145,8 +1237,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1157,8 +1251,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1169,8 +1264,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1200,8 +1296,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1212,8 +1309,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1224,8 +1322,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1236,8 +1335,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1361,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1388,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1296,8 +1401,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1308,8 +1414,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1320,8 +1427,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1332,8 +1440,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1344,8 +1454,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1356,8 +1467,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1387,8 +1499,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1418,8 +1531,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1430,8 +1544,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_location",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1442,8 +1557,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1454,8 +1570,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1466,8 +1583,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1478,8 +1597,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1490,8 +1610,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1502,8 +1623,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1514,8 +1636,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1545,8 +1668,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1557,8 +1681,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1694,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1707,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1720,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1733,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1617,8 +1746,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1759,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1641,8 +1772,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1786,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1665,8 +1799,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1677,8 +1812,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1689,8 +1825,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1701,8 +1838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1713,8 +1851,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1725,8 +1864,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1756,8 +1896,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1768,8 +1909,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1922,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1792,8 +1935,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1804,8 +1948,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1816,8 +1962,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1828,8 +1975,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1840,8 +1988,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1852,8 +2001,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1864,8 +2014,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1895,8 +2046,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1926,8 +2078,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1957,8 +2110,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1969,8 +2123,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2149,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2005,8 +2162,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2175,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2188,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2041,8 +2201,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2053,8 +2214,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2228,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2077,8 +2241,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2089,8 +2254,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2101,8 +2268,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2113,8 +2281,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2294,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2137,8 +2308,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2321,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2161,8 +2334,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2347,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2185,8 +2360,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2197,8 +2373,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2208,9 +2385,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2221,8 +2399,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2233,8 +2412,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2245,8 +2425,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2257,8 +2439,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2269,8 +2453,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2281,8 +2466,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2293,8 +2479,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2305,8 +2492,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2336,8 +2524,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2348,8 +2537,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2360,8 +2550,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2372,8 +2563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2384,8 +2576,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2396,8 +2589,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2408,8 +2603,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2420,8 +2616,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2432,8 +2629,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2444,8 +2642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2475,8 +2674,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2487,8 +2687,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2499,8 +2700,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2511,8 +2713,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2523,8 +2726,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2535,8 +2740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2547,8 +2753,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2559,8 +2766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2590,8 +2798,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2602,8 +2812,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2614,8 +2825,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2626,8 +2838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2638,8 +2851,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2650,8 +2864,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2662,8 +2878,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2674,8 +2891,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2686,8 +2904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2698,8 +2917,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2729,8 +2949,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2741,20 +2962,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2765,8 +2975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2777,8 +2988,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2789,8 +3001,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2801,8 +3014,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2813,8 +3027,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2825,8 +3041,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2837,8 +3056,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2849,8 +3069,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2861,8 +3082,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2873,8 +3096,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2885,8 +3110,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2897,8 +3123,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2909,8 +3137,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2921,8 +3150,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2933,8 +3163,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -2945,8 +3176,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2957,8 +3189,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2988,8 +3221,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3000,8 +3234,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3012,8 +3247,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3024,8 +3260,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3036,8 +3273,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3048,8 +3286,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3060,8 +3299,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3072,8 +3312,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3084,8 +3325,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3096,8 +3339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3108,8 +3352,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3120,8 +3365,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3132,8 +3378,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3144,8 +3391,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3156,8 +3404,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3168,8 +3417,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3180,8 +3430,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3211,8 +3462,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3223,8 +3475,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3235,8 +3488,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3247,8 +3501,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3259,8 +3514,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3271,8 +3527,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3283,8 +3541,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3295,8 +3554,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3307,8 +3567,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3319,8 +3580,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3331,8 +3593,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3343,8 +3607,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3355,8 +3620,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3386,8 +3652,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3665,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3678,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3422,8 +3691,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3434,8 +3704,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3446,8 +3717,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3458,8 +3730,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3470,8 +3743,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3482,8 +3756,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3494,8 +3769,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "duplex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3506,8 +3782,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3518,8 +3795,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3530,8 +3809,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3542,8 +3822,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3554,8 +3835,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3566,8 +3848,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3578,8 +3861,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3590,8 +3874,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3602,8 +3887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3614,8 +3900,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3626,8 +3913,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3638,8 +3926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3650,8 +3939,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3662,8 +3953,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3674,8 +3966,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3686,8 +3979,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3698,8 +3992,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_frequency",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3710,8 +4005,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3722,8 +4018,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3734,8 +4031,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3746,8 +4044,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3758,8 +4057,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3770,8 +4070,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tx_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3782,8 +4083,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3794,8 +4096,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3806,8 +4109,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vdcs",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3818,8 +4122,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3830,8 +4135,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_lans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3842,8 +4148,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_link",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3854,8 +4161,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wwn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3885,8 +4193,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3897,8 +4206,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3909,8 +4219,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3921,8 +4232,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3933,8 +4245,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3945,8 +4258,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3957,8 +4271,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3969,8 +4285,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3981,8 +4298,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3993,8 +4311,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4005,8 +4324,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4017,8 +4337,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4029,8 +4350,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4041,8 +4363,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4053,8 +4376,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4084,8 +4408,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4096,8 +4421,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4108,8 +4434,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4120,8 +4447,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4132,8 +4460,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4199,8 +4528,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4211,8 +4541,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4223,8 +4554,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4235,8 +4567,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4247,8 +4581,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4259,8 +4594,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4271,8 +4608,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4283,8 +4622,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4295,8 +4635,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4307,8 +4648,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4319,8 +4662,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4331,8 +4676,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4343,8 +4690,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4355,8 +4703,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4367,8 +4717,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4379,8 +4730,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4410,8 +4763,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4422,8 +4776,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4434,8 +4790,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4446,8 +4803,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4458,8 +4816,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4470,8 +4829,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4482,8 +4842,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4494,8 +4855,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4506,8 +4868,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4537,8 +4900,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4549,8 +4913,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4561,8 +4926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4573,8 +4939,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4585,8 +4954,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4597,8 +4967,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4609,8 +4981,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4712,8 +5085,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4724,8 +5098,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4736,8 +5111,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4748,8 +5124,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4760,8 +5138,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4772,8 +5151,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4784,8 +5164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4796,8 +5177,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "napalm_args",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4808,8 +5190,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "napalm_driver",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4820,8 +5203,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4851,8 +5235,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4863,8 +5248,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4875,8 +5261,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4887,8 +5274,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4899,8 +5287,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4911,8 +5300,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4923,8 +5313,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4935,8 +5326,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4947,8 +5339,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4959,8 +5352,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4971,8 +5366,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4983,8 +5379,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4995,8 +5392,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -5007,8 +5405,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5019,8 +5418,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -5031,8 +5431,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5043,8 +5444,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5055,8 +5457,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -5067,8 +5471,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -5079,8 +5484,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -5091,8 +5497,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -5122,8 +5529,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5134,8 +5542,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5146,8 +5555,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5158,8 +5568,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5170,8 +5581,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5182,8 +5594,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5194,8 +5607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5206,8 +5620,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5218,8 +5633,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5230,8 +5646,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5242,8 +5660,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5254,8 +5673,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5266,8 +5686,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5278,8 +5699,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5290,8 +5712,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5302,8 +5725,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5314,8 +5738,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5345,8 +5770,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5357,8 +5783,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5369,8 +5796,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5381,8 +5809,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5393,8 +5822,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5405,8 +5835,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5417,8 +5849,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5429,8 +5862,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5441,8 +5875,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5453,8 +5888,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5465,8 +5901,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5477,8 +5915,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5508,8 +5947,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5520,8 +5960,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5532,8 +5973,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5544,8 +5986,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5556,8 +5999,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5568,8 +6013,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5580,8 +6026,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5592,8 +6040,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5603,9 +6052,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5616,8 +6066,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5647,8 +6099,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5659,8 +6112,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5671,8 +6125,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5683,8 +6138,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5695,8 +6151,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5707,8 +6164,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5719,8 +6177,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5731,8 +6190,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5743,8 +6203,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5755,8 +6216,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5767,8 +6230,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5779,8 +6243,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5791,8 +6256,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5803,8 +6269,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5815,8 +6282,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5827,8 +6295,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5839,8 +6308,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5870,8 +6340,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5882,8 +6353,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5894,8 +6366,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5906,8 +6379,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5918,8 +6392,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5930,8 +6405,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5942,8 +6419,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5954,8 +6432,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5966,8 +6445,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5978,8 +6458,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5990,8 +6471,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6002,8 +6484,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6033,8 +6516,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_max_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6045,8 +6529,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6057,8 +6542,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6069,8 +6555,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6081,8 +6568,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6093,8 +6581,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6105,8 +6594,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6117,8 +6607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -6129,8 +6620,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6141,8 +6633,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6153,8 +6646,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6165,8 +6660,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6177,8 +6673,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6189,8 +6687,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6201,8 +6700,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mounting_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6213,8 +6713,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6225,8 +6726,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6237,8 +6739,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6249,8 +6752,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6260,9 +6764,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6273,8 +6778,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6285,8 +6792,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6297,8 +6805,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6309,8 +6819,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6321,8 +6833,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6333,8 +6846,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6345,8 +6859,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -6357,8 +6872,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6369,8 +6885,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6381,8 +6898,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -6412,8 +6930,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6424,8 +6943,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6436,8 +6956,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6448,8 +6969,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6460,8 +6982,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6472,8 +6996,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6484,8 +7009,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6496,8 +7022,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6508,8 +7035,10 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6520,8 +7049,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6551,8 +7081,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -6563,8 +7095,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6575,8 +7108,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6587,8 +7121,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6599,8 +7134,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6611,8 +7147,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6623,8 +7161,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6635,8 +7174,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6647,8 +7187,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6678,8 +7219,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6690,8 +7232,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6702,8 +7245,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6714,8 +7258,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6726,8 +7271,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6738,8 +7284,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6750,8 +7297,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6762,8 +7310,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6774,8 +7323,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6786,8 +7337,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6798,8 +7350,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6810,8 +7363,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6822,8 +7376,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6834,8 +7389,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6846,8 +7402,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6858,8 +7415,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6889,8 +7447,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6901,8 +7460,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6913,8 +7473,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6925,8 +7486,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6937,8 +7499,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6949,8 +7512,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6961,8 +7526,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6973,8 +7539,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6985,8 +7552,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6997,8 +7565,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7009,8 +7578,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -7021,8 +7591,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7052,8 +7623,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7064,8 +7636,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7076,8 +7649,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7088,8 +7662,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7100,8 +7676,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7112,8 +7689,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7124,8 +7703,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7136,8 +7717,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7148,8 +7730,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7160,8 +7743,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7172,8 +7756,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7184,8 +7770,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7196,8 +7783,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7208,8 +7796,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7239,8 +7829,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7251,8 +7842,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7263,8 +7855,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7275,8 +7868,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7287,8 +7881,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7299,8 +7894,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7311,8 +7907,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7323,8 +7920,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7335,8 +7934,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7347,8 +7948,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7359,8 +7961,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7371,8 +7974,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7383,8 +7987,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7395,8 +8000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7407,8 +8013,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7419,8 +8026,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7431,8 +8039,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7443,8 +8053,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7455,8 +8066,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7467,8 +8079,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7479,8 +8092,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7491,8 +8106,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7503,8 +8119,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7515,8 +8132,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7546,8 +8164,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7558,8 +8177,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7570,8 +8190,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7582,8 +8203,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7594,8 +8216,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7606,8 +8230,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7618,8 +8243,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7630,8 +8257,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7642,8 +8271,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7654,8 +8284,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7666,8 +8297,10 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7678,8 +8311,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7690,8 +8325,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7702,8 +8338,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7733,8 +8371,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7745,8 +8384,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7757,8 +8397,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7769,8 +8410,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7781,8 +8423,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "domain",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7793,8 +8436,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7805,8 +8450,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7817,8 +8463,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "master",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7829,8 +8476,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7932,8 +8580,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7981,8 +8630,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7993,8 +8643,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8005,8 +8657,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8017,8 +8671,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8029,8 +8684,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8041,8 +8697,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8053,8 +8710,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -8065,8 +8723,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "group_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8077,8 +8736,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8089,8 +8750,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8101,8 +8763,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8113,8 +8776,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8125,8 +8790,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8137,8 +8803,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -8149,8 +8816,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "search_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8161,8 +8829,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -8173,8 +8842,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "ui_visibility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8185,8 +8855,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8197,8 +8868,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8209,8 +8881,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8221,8 +8894,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -8252,8 +8926,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8264,8 +8939,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8276,8 +8952,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8325,8 +9002,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8356,8 +9034,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8387,8 +9066,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8418,8 +9098,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8449,8 +9130,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8480,8 +9162,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8492,8 +9175,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8504,8 +9188,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8553,8 +9238,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8565,8 +9251,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8652,8 +9339,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8664,8 +9352,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8676,8 +9365,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8707,8 +9397,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8719,8 +9410,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8731,8 +9423,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8743,8 +9436,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8755,8 +9449,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8767,8 +9463,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8779,8 +9476,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8791,8 +9489,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8822,8 +9521,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8834,8 +9535,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8846,8 +9549,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8858,8 +9563,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8889,8 +9596,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8920,8 +9628,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8932,8 +9641,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8944,8 +9654,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8956,8 +9667,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8968,8 +9680,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8980,8 +9693,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8992,8 +9707,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9004,8 +9720,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9016,8 +9733,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9028,8 +9746,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9040,8 +9759,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9089,8 +9809,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9101,8 +9822,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -9150,8 +9872,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9162,8 +9885,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9174,8 +9898,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9186,8 +9911,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9198,8 +9924,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9210,8 +9937,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9222,8 +9950,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9234,8 +9963,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "dns_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9246,8 +9976,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9258,8 +9990,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9270,8 +10003,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "nat_inside",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9282,8 +10016,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9294,8 +10030,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9306,8 +10044,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9318,8 +10057,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9403,8 +10143,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9415,8 +10156,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9427,8 +10169,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9439,8 +10182,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9451,8 +10195,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9463,8 +10208,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9475,8 +10221,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9487,8 +10235,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9499,8 +10248,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9511,8 +10261,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9523,8 +10274,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9535,8 +10287,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9546,9 +10299,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9559,8 +10313,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9571,8 +10327,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9583,8 +10341,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9595,8 +10355,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9607,8 +10368,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9619,8 +10381,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9650,8 +10413,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9662,8 +10426,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9674,8 +10439,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9686,8 +10452,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9698,8 +10466,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -9710,8 +10479,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9722,8 +10492,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9734,8 +10505,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9765,8 +10537,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -9777,8 +10550,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9789,8 +10563,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9801,8 +10576,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9813,8 +10589,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9825,8 +10602,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9837,8 +10616,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9849,8 +10629,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9861,8 +10642,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9873,8 +10655,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9904,8 +10687,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9916,8 +10700,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9928,8 +10713,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9940,8 +10726,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9952,8 +10739,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9964,8 +10753,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9976,8 +10766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9988,8 +10779,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10019,8 +10811,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10068,8 +10861,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10080,8 +10874,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10092,8 +10887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10104,8 +10900,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10116,8 +10913,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10128,8 +10927,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10140,8 +10941,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10152,8 +10954,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10164,8 +10967,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10175,9 +10979,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10188,8 +10993,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10200,8 +11007,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10212,8 +11021,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -10224,8 +11035,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10236,8 +11048,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10267,8 +11080,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10279,8 +11093,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10291,8 +11106,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10303,8 +11119,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10315,8 +11133,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10327,8 +11146,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10339,8 +11159,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "min_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10351,8 +11172,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10363,8 +11185,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10375,8 +11198,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10387,8 +11211,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10418,8 +11243,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10430,8 +11256,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10442,8 +11269,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10454,8 +11282,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10466,8 +11295,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enforce_unique",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10478,8 +11308,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "export_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10490,8 +11321,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10502,8 +11335,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "import_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10514,8 +11348,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10526,8 +11361,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10538,8 +11374,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "rd",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10550,8 +11387,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10653,8 +11491,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10684,8 +11523,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10715,8 +11555,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10746,8 +11587,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10777,8 +11619,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10808,8 +11651,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10839,8 +11683,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10870,8 +11715,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10973,8 +11819,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10985,8 +11832,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10997,8 +11845,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11009,8 +11858,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11021,8 +11871,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11033,8 +11885,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11045,8 +11899,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11057,8 +11912,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11069,8 +11925,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11100,8 +11957,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11112,8 +11970,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11124,8 +11983,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11136,8 +11996,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11148,8 +12010,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11160,8 +12023,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11172,8 +12037,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11184,8 +12051,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11196,8 +12064,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11208,8 +12077,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11220,8 +12091,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11232,8 +12104,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -11263,8 +12137,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11312,8 +12187,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11343,8 +12219,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11392,8 +12269,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11404,8 +12282,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11416,8 +12295,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11428,8 +12308,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11440,8 +12321,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11452,8 +12335,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11464,8 +12349,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11476,8 +12362,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11488,8 +12375,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11499,9 +12387,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11512,8 +12401,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11524,8 +12415,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11536,8 +12428,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11548,8 +12441,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11579,8 +12474,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11591,8 +12487,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11603,8 +12500,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11615,8 +12513,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11627,8 +12527,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11639,8 +12540,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11651,8 +12553,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11682,8 +12585,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11694,8 +12598,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11706,8 +12611,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11718,8 +12624,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11730,8 +12638,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11742,8 +12651,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11754,8 +12664,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11785,8 +12696,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11797,8 +12709,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11809,8 +12722,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11821,8 +12735,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11833,8 +12748,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11845,8 +12761,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11857,8 +12774,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11869,8 +12787,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11881,8 +12800,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11893,8 +12814,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11905,8 +12827,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11917,8 +12840,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11929,8 +12853,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11941,8 +12866,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11953,8 +12879,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11965,8 +12892,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11977,8 +12905,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11989,8 +12919,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12001,8 +12932,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -12013,8 +12946,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12025,8 +12959,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -12056,8 +12991,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12068,8 +13004,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12080,8 +13017,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12092,8 +13030,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12104,8 +13043,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12116,8 +13056,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -12128,8 +13069,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12140,8 +13083,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -12152,8 +13096,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12164,8 +13109,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12176,8 +13122,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12188,8 +13135,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12200,8 +13148,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12212,8 +13162,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -12224,8 +13175,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12236,8 +13188,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12248,8 +13201,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12260,8 +13214,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.5/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.5/summary.txt
@@ -120,56 +120,15 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
 dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
-dcim.inventoryitemrole => dcim.inventoryitemrole | Disabled with reason: Nautobot content type: `dcim.inventoryitemrole` not found
-dcim.inventoryitemtemplate => dcim.inventoryitemtemplate | Disabled with reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-dcim.module => dcim.module | Disabled with reason: Nautobot content type: `dcim.module` not found
-dcim.modulebay => dcim.modulebay | Disabled with reason: Nautobot content type: `dcim.modulebay` not found
-dcim.modulebaytemplate => dcim.modulebaytemplate | Disabled with reason: Nautobot content type: `dcim.modulebaytemplate` not found
-dcim.moduletype => dcim.moduletype | Disabled with reason: Nautobot content type: `dcim.moduletype` not found
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
-dcim.virtualdevicecontext => dcim.virtualdevicecontext | Disabled with reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
-extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
-extras.stagedchange => extras.stagedchange | Disabled with reason: Nautobot content type: `extras.stagedchange` not found
 ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
-ipam.l2vpn => ipam.l2vpn | Disabled with reason: Nautobot content type: `ipam.l2vpn` not found
-ipam.l2vpntermination => ipam.l2vpntermination | Disabled with reason: Nautobot content type: `ipam.l2vpntermination` not found
 ipam.role => extras.role
-ipam.servicetemplate => ipam.servicetemplate | Disabled with reason: Nautobot content type: `ipam.servicetemplate` not found
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
@@ -177,999 +136,811 @@ dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
 dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-provider_account (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_date (DATA) => NO IMPORTER => NO TARGET
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+provider_account => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_date => NO IMPORTER => NO TARGET
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-service_id (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
+service_id => NO IMPORTER => NO TARGET
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
+_abs_length => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+tenant => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.cabletermination => dcim.cable **************************************************************
-_device (DATA) => NO IMPORTER => NO TARGET
-_location (DATA) => NO IMPORTER => NO TARGET
-_rack (DATA) => NO IMPORTER => NO TARGET
-_site (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
+_device => NO IMPORTER => NO TARGET
+_location => NO IMPORTER => NO TARGET
+_rack => NO IMPORTER => NO TARGET
+_site => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device_role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device_role => relation_importer => role_id (RoleField)
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
+_abs_weight => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
 * dcim.frontport => dcim.frontport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-duplex (DATA) => NO IMPORTER => NO TARGET
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-module (DATA) => NO IMPORTER => NO TARGET
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-rf_channel (DATA) => NO IMPORTER => NO TARGET
-rf_channel_frequency (DATA) => NO IMPORTER => NO TARGET
-rf_channel_width (DATA) => NO IMPORTER => NO TARGET
-rf_role (DATA) => NO IMPORTER => NO TARGET
-speed (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-tx_power (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-vdcs (DATA) => NO IMPORTER => NO TARGET
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-wireless_lans (DATA) => NO IMPORTER => NO TARGET
-wireless_link (DATA) => NO IMPORTER => NO TARGET
-wwn (DATA) => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+duplex => NO IMPORTER => NO TARGET
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+module => NO IMPORTER => NO TARGET
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+rf_channel => NO IMPORTER => NO TARGET
+rf_channel_frequency => NO IMPORTER => NO TARGET
+rf_channel_width => NO IMPORTER => NO TARGET
+rf_role => NO IMPORTER => NO TARGET
+speed => NO IMPORTER => NO TARGET
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+tx_power => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+vdcs => NO IMPORTER => NO TARGET
+vrf => relation_importer => vrf_id (ForeignKey)
+wireless_lans => NO IMPORTER => NO TARGET
+wireless_link => NO IMPORTER => NO TARGET
+wwn => NO IMPORTER => NO TARGET
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-enabled (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.inventoryitemrole => dcim.inventoryitemrole *************************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemrole` not found
-* dcim.inventoryitemtemplate => dcim.inventoryitemtemplate *****************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
+_name => NO IMPORTER => NO TARGET
+bridge => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+enabled => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-* dcim.module => dcim.module ***********************************************************************
-    Disable reason: Nautobot content type: `dcim.module` not found
-* dcim.modulebay => dcim.modulebay *****************************************************************
-    Disable reason: Nautobot content type: `dcim.modulebay` not found
-* dcim.modulebaytemplate => dcim.modulebaytemplate *************************************************
-    Disable reason: Nautobot content type: `dcim.modulebaytemplate` not found
-* dcim.moduletype => dcim.moduletype ***************************************************************
-    Disable reason: Nautobot content type: `dcim.moduletype` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-napalm_args (DATA) => json_importer => napalm_args (JSONField)
-napalm_driver (DATA) => value_importer => napalm_driver (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+napalm_args => json_importer => napalm_args (JSONField)
+napalm_driver => value_importer => napalm_driver (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_abs_max_weight (DATA) => NO IMPORTER => NO TARGET
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-description (DATA) => NO IMPORTER => NO TARGET
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-max_weight (DATA) => NO IMPORTER => NO TARGET
-mounting_depth (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
+_abs_max_weight => NO IMPORTER => NO TARGET
+_abs_weight => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+description => NO IMPORTER => NO TARGET
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+max_weight => NO IMPORTER => NO TARGET
+mounting_depth => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackreservation => dcim.rackreservation *****************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-units (DATA) (CUSTOM) => units_importer => units (JSONField)
-user (DATA) => relation_importer => user_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+rack => relation_importer => rack_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+units => units_importer => units (JSONField)
+user => relation_importer => user_id (ForeignKey)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (DATA) (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => constant_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.virtualchassis => dcim.virtualchassis *******************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-domain (DATA) => value_importer => domain (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-master (DATA) => relation_importer => master_id (OneToOneField)
-name (DATA) => value_importer => name (CharField)
-* dcim.virtualdevicecontext => dcim.virtualdevicecontext *******************************************
-    Disable reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.branch => extras.branch *******************************************************************
-    Disable reason: Nautobot content type: `extras.branch` not found
-* extras.cachedvalue => extras.cachedvalue *********************************************************
-    Disable reason: Nautobot content type: `extras.cachedvalue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+domain => value_importer => domain (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+master => relation_importer => master_id (OneToOneField)
+name => value_importer => name (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (CUSTOM) => choices_importer => Custom Target
-choices (DATA) (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-group_name (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-object_type (DATA) => NO IMPORTER => NO TARGET
-required (DATA) => value_importer => required (BooleanField)
-search_weight (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-ui_visibility (DATA) => NO IMPORTER => NO TARGET
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.savedfilter => extras.savedfilter *********************************************************
-    Disable reason: Nautobot content type: `extras.savedfilter` not found
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.stagedchange => extras.stagedchange *******************************************************
-    Disable reason: Nautobot content type: `extras.stagedchange` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
+choices => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+group_name => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+object_type => NO IMPORTER => NO TARGET
+required => value_importer => required (BooleanField)
+search_weight => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+ui_visibility => NO IMPORTER => NO TARGET
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.tag => extras.tag *************************************************************************
-color (DATA) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (DATA) => tagged_object_importer => content_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (DATA) (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (DATA) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+content_type => tagged_object_importer => content_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_id => tagged_object_importer => object_id (UUIDField)
+tag => tagged_object_importer => tag_id (ForeignKey)
 * ipam.aggregate => ipam.prefix ********************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.ipaddress => ipam.ipaddress *****************************************************************
-address (DATA) => value_importer => address (Property)
-assigned_object_id (DATA) => NO IMPORTER => NO TARGET
-assigned_object_type (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-dns_name (DATA) => value_importer => dns_name (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-nat_inside (DATA) => relation_importer => nat_inside_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
-* ipam.l2vpn => ipam.l2vpn *************************************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpn` not found
-* ipam.l2vpntermination => ipam.l2vpntermination ***************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpntermination` not found
+address => value_importer => address (Property)
+assigned_object_id => NO IMPORTER => NO TARGET
+assigned_object_type => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+dns_name => value_importer => dns_name (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+nat_inside => relation_importer => nat_inside_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.routetarget => ipam.routetarget *************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.servicetemplate => ipam.servicetemplate *****************************************************
-    Disable reason: Nautobot content type: `ipam.servicetemplate` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.vlan => ipam.vlan ***************************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-max_vid (DATA) => NO IMPORTER => NO TARGET
-min_vid (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+max_vid => NO IMPORTER => NO TARGET
+min_vid => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * ipam.vrf => ipam.vrf *****************************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enforce_unique (DATA) => NO IMPORTER => NO TARGET
-export_targets (DATA) => uuids_importer => export_targets (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-import_targets (DATA) => uuids_importer => import_targets (ManyToManyField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rd (DATA) => value_importer => rd (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enforce_unique => NO IMPORTER => NO TARGET
+export_targets => uuids_importer => export_targets (ManyToManyField)
+id => uid_from_data => id (UUIDField)
+import_targets => uuids_importer => import_targets (ManyToManyField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rd => value_importer => rd (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => NO IMPORTER => NO TARGET
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+status => NO IMPORTER => NO TARGET
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device (DATA) => NO IMPORTER => NO TARGET
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device => NO IMPORTER => NO TARGET
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+site => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+_name => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.json
@@ -49,8 +49,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -82,8 +83,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -94,8 +96,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -106,8 +109,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -137,8 +142,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -170,8 +176,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -182,8 +189,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -194,8 +202,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -206,8 +215,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -218,8 +228,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -230,8 +241,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -242,8 +254,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -254,8 +267,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -266,8 +280,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -278,8 +294,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -290,8 +307,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -302,8 +321,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -314,8 +335,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -345,8 +367,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -357,8 +380,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -369,8 +393,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -381,8 +406,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -393,8 +419,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -424,8 +451,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -436,8 +464,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,9 +476,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -459,9 +489,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -491,8 +522,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -522,8 +554,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -571,8 +604,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -605,8 +639,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -617,8 +653,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -629,8 +666,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -750,8 +788,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -762,8 +801,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -793,8 +833,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -824,8 +865,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -855,8 +897,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -886,8 +929,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -917,8 +961,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -948,8 +993,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -979,8 +1025,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -991,8 +1038,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1003,8 +1051,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1015,8 +1064,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1027,8 +1077,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1039,8 +1090,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "config_template",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1103,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "console_port_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1116,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "console_server_port_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1129,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1087,8 +1142,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1155,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1111,8 +1168,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "device_bay_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1123,8 +1181,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1135,8 +1194,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1147,8 +1207,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1159,8 +1220,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "front_port_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1171,8 +1233,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1183,8 +1247,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "interface_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1195,8 +1260,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "inventory_item_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1207,8 +1273,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1219,8 +1286,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1231,8 +1299,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1243,8 +1312,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1255,8 +1326,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1267,8 +1339,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_bay_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1279,8 +1352,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1291,8 +1365,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "oob_ip",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1303,8 +1378,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1315,8 +1391,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1327,8 +1404,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "power_outlet_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1339,8 +1417,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "power_port_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1351,8 +1430,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1363,8 +1443,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1375,8 +1456,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1387,8 +1469,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rear_port_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1398,9 +1481,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1411,8 +1495,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1423,8 +1509,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1435,8 +1522,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1447,8 +1536,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1459,8 +1550,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1471,8 +1563,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1483,8 +1576,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1495,8 +1589,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1526,8 +1621,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1557,8 +1653,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1588,8 +1685,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -1600,8 +1699,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "config_template",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1612,8 +1712,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1624,8 +1725,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1636,8 +1738,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1648,8 +1751,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1660,8 +1764,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1672,8 +1778,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1684,8 +1791,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1696,8 +1804,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1708,8 +1817,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1739,8 +1849,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1751,20 +1862,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1775,8 +1875,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1787,8 +1888,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "console_port_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1799,8 +1901,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "console_server_port_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1811,8 +1914,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1823,8 +1927,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1835,8 +1940,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "default_platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1847,8 +1953,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1859,8 +1966,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "device_bay_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1871,8 +1979,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -1883,8 +1993,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "front_port_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1895,8 +2006,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1907,8 +2021,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "interface_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1919,8 +2034,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "inventory_item_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1931,8 +2047,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -1943,8 +2060,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1955,8 +2073,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -1967,8 +2087,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1979,8 +2101,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_bay_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1991,8 +2114,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2003,8 +2127,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "power_outlet_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2015,8 +2140,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "power_port_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2027,8 +2153,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2039,8 +2167,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rear_port_template_count",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2051,8 +2180,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2063,8 +2193,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2075,8 +2206,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -2087,8 +2219,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2099,8 +2232,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2130,8 +2264,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2161,8 +2296,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2309,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2204,8 +2341,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2216,8 +2354,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2228,8 +2367,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -2259,8 +2399,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2290,8 +2431,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2302,8 +2444,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2314,8 +2457,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2326,8 +2470,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2338,8 +2483,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -2405,8 +2551,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2417,8 +2564,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2429,8 +2577,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2441,8 +2590,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2453,8 +2603,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2465,8 +2616,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2476,9 +2628,10 @@
                     "nautobot_internal_type": "TreeNodeForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
-                    "definition": "parent_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2489,8 +2642,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2501,8 +2655,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -2532,8 +2687,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2544,8 +2700,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2556,8 +2714,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2568,8 +2727,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2580,8 +2740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2592,8 +2753,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -2604,8 +2766,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2616,8 +2779,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -2628,8 +2792,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -2659,8 +2824,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2671,8 +2837,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2683,8 +2850,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2695,8 +2863,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2707,8 +2878,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2719,8 +2891,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2731,8 +2905,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2834,8 +3009,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2865,8 +3041,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2896,8 +3073,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2927,8 +3105,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2939,8 +3118,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2970,8 +3150,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2982,8 +3163,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2993,9 +3175,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3005,9 +3188,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3037,8 +3221,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3068,8 +3253,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3099,8 +3285,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3111,8 +3298,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3122,9 +3310,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3135,8 +3324,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3146,9 +3336,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3159,8 +3350,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -3190,8 +3382,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3202,8 +3395,9 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3233,8 +3427,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -3245,8 +3440,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3257,8 +3453,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3288,8 +3485,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3319,8 +3517,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3350,8 +3549,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3362,8 +3562,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3374,8 +3575,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3386,8 +3588,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3601,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3410,8 +3614,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3422,8 +3627,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3453,8 +3659,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3465,8 +3672,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3477,8 +3685,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3489,8 +3698,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3501,8 +3711,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3513,8 +3724,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3525,8 +3737,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3537,8 +3750,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3549,8 +3764,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3561,8 +3778,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3573,8 +3791,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3585,8 +3804,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3597,8 +3817,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3609,8 +3830,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3621,8 +3843,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3633,8 +3856,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3645,8 +3869,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3657,8 +3883,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3669,8 +3896,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3681,8 +3909,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3693,8 +3922,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3705,8 +3936,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3717,8 +3949,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3729,8 +3962,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3760,8 +3994,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3772,8 +4007,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3784,8 +4020,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3796,8 +4033,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3808,8 +4046,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3820,8 +4059,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3832,8 +4072,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -3844,8 +4085,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -3875,8 +4117,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3996,8 +4239,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4063,8 +4307,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4075,8 +4321,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4087,8 +4334,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4099,8 +4348,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4111,8 +4361,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4123,8 +4374,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4135,8 +4387,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -4147,8 +4400,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "group_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4159,8 +4413,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4171,8 +4427,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_cloneable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4183,8 +4440,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4195,8 +4453,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4207,8 +4466,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4219,8 +4480,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4231,8 +4493,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4243,8 +4506,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "search_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4255,8 +4519,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -4267,8 +4532,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "ui_visibility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4279,8 +4545,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4291,8 +4558,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4303,8 +4571,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4315,8 +4584,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -4346,8 +4616,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4358,8 +4629,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4370,8 +4642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4419,8 +4692,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4468,8 +4742,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4499,8 +4774,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4530,8 +4806,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4561,8 +4838,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4573,8 +4851,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4585,8 +4864,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4597,8 +4877,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4609,8 +4890,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "created_by",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4621,8 +4903,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4633,8 +4916,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4645,8 +4930,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "kind",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4657,8 +4943,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 }
@@ -4688,8 +4975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "action",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4700,8 +4988,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "changed_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4712,8 +5001,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "changed_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4724,8 +5014,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4736,8 +5028,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "object_repr",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4748,8 +5041,10 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4760,8 +5055,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "prechange_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4772,8 +5068,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "related_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4784,8 +5081,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "related_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4796,8 +5094,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuid_importer",
                     "definition": "request_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4808,8 +5107,10 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4820,8 +5121,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4832,8 +5134,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "user_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4899,8 +5202,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4911,8 +5215,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5016,8 +5321,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5028,8 +5334,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5040,8 +5347,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5071,8 +5379,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5083,8 +5392,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5114,8 +5424,9 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5126,8 +5437,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5138,8 +5450,9 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5150,8 +5463,9 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5181,8 +5495,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5212,8 +5527,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5224,8 +5540,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -5291,8 +5608,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "auth_key",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5303,8 +5621,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "auth_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5315,8 +5634,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5327,8 +5647,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5339,8 +5660,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5351,8 +5673,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5363,8 +5686,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "group_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5375,8 +5699,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5387,8 +5713,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5399,8 +5726,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5411,8 +5739,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "protocol",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5423,8 +5752,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -5472,8 +5802,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5484,8 +5815,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5496,8 +5828,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -5581,8 +5914,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5593,8 +5927,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5604,9 +5939,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5617,8 +5953,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5628,9 +5965,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5641,8 +5979,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -5672,8 +6011,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5703,8 +6043,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -5715,8 +6056,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5727,8 +6069,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5758,8 +6101,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5789,8 +6133,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5838,8 +6183,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5850,8 +6196,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5862,8 +6209,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5873,9 +6221,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5886,8 +6235,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5897,9 +6247,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5910,8 +6261,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -5941,8 +6293,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5972,8 +6325,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6075,8 +6429,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6106,8 +6461,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6137,8 +6493,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6168,8 +6525,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6199,8 +6557,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6230,8 +6589,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6261,8 +6621,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6292,8 +6653,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6395,8 +6757,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6407,8 +6770,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6419,8 +6783,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6431,8 +6796,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6443,8 +6809,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6455,8 +6823,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6467,8 +6837,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6479,8 +6850,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6491,8 +6863,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6522,8 +6895,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6534,8 +6908,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6546,8 +6921,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6558,8 +6934,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6570,8 +6948,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6582,8 +6961,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6594,8 +6975,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6606,8 +6989,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6618,8 +7002,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6630,8 +7015,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -6642,8 +7029,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6654,8 +7042,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -6685,8 +7075,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6770,8 +7161,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6801,8 +7193,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6850,8 +7243,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6862,8 +7256,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6874,8 +7269,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6885,9 +7281,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6897,9 +7294,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "site",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6910,8 +7308,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6941,8 +7340,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6972,8 +7372,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7003,8 +7404,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7015,8 +7417,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7027,8 +7430,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -7058,8 +7462,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7070,8 +7475,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7082,8 +7488,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.6.custom/summary.txt
@@ -30,647 +30,231 @@ c75ebf9a-0f74-5c7f-982b-a1a42faf5b09 Site 1 | {'parent': ['A Location of type Si
 Total validation issues: 1
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-account.usertoken => account.usertoken | Disabled with reason: Nautobot content type: `account.usertoken` not found
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-circuits.provideraccount => circuits.provideraccount | Disabled with reason: Nautobot content type: `circuits.provideraccount` not found
-core.autosyncrecord => core.autosyncrecord | Disabled with reason: Nautobot content type: `core.autosyncrecord` not found
-core.datafile => core.datafile | Disabled with reason: Nautobot content type: `core.datafile` not found
-core.datasource => core.datasource | Disabled with reason: Nautobot content type: `core.datasource` not found
-core.job => core.job | Disabled with reason: Nautobot content type: `core.job` not found
-core.managedfile => core.managedfile | Disabled with reason: Nautobot content type: `core.managedfile` not found
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
-dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
-dcim.inventoryitemrole => dcim.inventoryitemrole | Disabled with reason: Nautobot content type: `dcim.inventoryitemrole` not found
-dcim.inventoryitemtemplate => dcim.inventoryitemtemplate | Disabled with reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-dcim.module => dcim.module | Disabled with reason: Nautobot content type: `dcim.module` not found
-dcim.modulebay => dcim.modulebay | Disabled with reason: Nautobot content type: `dcim.modulebay` not found
-dcim.modulebaytemplate => dcim.modulebaytemplate | Disabled with reason: Nautobot content type: `dcim.modulebaytemplate` not found
-dcim.moduletype => dcim.moduletype | Disabled with reason: Nautobot content type: `dcim.moduletype` not found
-dcim.rackrole => extras.role
-dcim.region => dcim.location
 dcim.site => dcim.location
-dcim.sitegroup => dcim.locationtype
-dcim.virtualdevicecontext => dcim.virtualdevicecontext | Disabled with reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.bookmark => extras.bookmark | Disabled with reason: Nautobot content type: `extras.bookmark` not found
-extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
-extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.configtemplate => extras.configtemplate | Disabled with reason: Nautobot content type: `extras.configtemplate` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.dashboard => extras.dashboard | Disabled with reason: Nautobot content type: `extras.dashboard` not found
 extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.reportmodule => extras.reportmodule | Disabled with reason: Nautobot content type: `extras.reportmodule` not found
-extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
-extras.scriptmodule => extras.scriptmodule | Disabled with reason: Nautobot content type: `extras.scriptmodule` not found
-extras.stagedchange => extras.stagedchange | Disabled with reason: Nautobot content type: `extras.stagedchange` not found
-ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.asnrange => ipam.asnrange | Disabled with reason: Nautobot content type: `ipam.asnrange` not found
 ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
-ipam.l2vpn => ipam.l2vpn | Disabled with reason: Nautobot content type: `ipam.l2vpn` not found
-ipam.l2vpntermination => ipam.l2vpntermination | Disabled with reason: Nautobot content type: `ipam.l2vpntermination` not found
-ipam.role => extras.role
-ipam.servicetemplate => ipam.servicetemplate | Disabled with reason: Nautobot content type: `ipam.servicetemplate` not found
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.netboxgroup => users.netboxgroup | Disabled with reason: Nautobot content type: `users.netboxgroup` not found
-users.netboxuser => users.netboxuser | Disabled with reason: Nautobot content type: `users.netboxuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
-dcim.cable => dcim.cabletermination
-extras.role => Ambiguous
-dcim.location => Ambiguous
-dcim.locationtype => dcim.sitegroup
+extras.role => dcim.devicerole
+dcim.location => dcim.site
 extras.note => extras.journalentry
-ipam.prefix => ipam.aggregate
 dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* account.usertoken => account.usertoken ***********************************************************
-    Disable reason: Nautobot content type: `account.usertoken` not found
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
-* circuits.circuit => circuits.circuit *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-termination_a (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_z (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
-* circuits.circuittermination => circuits.circuittermination ***************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-* circuits.circuittype => circuits.circuittype *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* circuits.provider => circuits.provider ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* circuits.provideraccount => circuits.provideraccount *********************************************
-    Disable reason: Nautobot content type: `circuits.provideraccount` not found
-* circuits.providernetwork => circuits.providernetwork *********************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
-* core.autosyncrecord => core.autosyncrecord *******************************************************
-    Disable reason: Nautobot content type: `core.autosyncrecord` not found
-* core.datafile => core.datafile *******************************************************************
-    Disable reason: Nautobot content type: `core.datafile` not found
-* core.datasource => core.datasource ***************************************************************
-    Disable reason: Nautobot content type: `core.datasource` not found
-* core.job => core.job *****************************************************************************
-    Disable reason: Nautobot content type: `core.job` not found
-* core.managedfile => core.managedfile *************************************************************
-    Disable reason: Nautobot content type: `core.managedfile` not found
-* dcim.cable => dcim.cable *************************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
-* dcim.cabletermination => dcim.cable **************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleport => dcim.consoleport *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-config_template (DATA) => NO IMPORTER => NO TARGET
-console_port_count (DATA) => NO IMPORTER => NO TARGET
-console_server_port_count (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device_bay_count (DATA) => NO IMPORTER => NO TARGET
-device_role (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-front_port_count (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-interface_count (DATA) => NO IMPORTER => NO TARGET
-inventory_item_count (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => NO IMPORTER => NO TARGET
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-longitude (DATA) => NO IMPORTER => NO TARGET
-module_bay_count (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-oob_ip (DATA) => NO IMPORTER => NO TARGET
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-power_outlet_count (DATA) => NO IMPORTER => NO TARGET
-power_port_count (DATA) => NO IMPORTER => NO TARGET
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-rear_port_count (DATA) => NO IMPORTER => NO TARGET
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
-* dcim.devicebay => dcim.devicebay *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+config_template => NO IMPORTER => NO TARGET
+console_port_count => NO IMPORTER => NO TARGET
+console_server_port_count => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device_bay_count => NO IMPORTER => NO TARGET
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+front_port_count => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+interface_count => NO IMPORTER => NO TARGET
+inventory_item_count => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => NO IMPORTER => NO TARGET
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+longitude => NO IMPORTER => NO TARGET
+module_bay_count => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+oob_ip => NO IMPORTER => NO TARGET
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+power_outlet_count => NO IMPORTER => NO TARGET
+power_port_count => NO IMPORTER => NO TARGET
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+rear_port_count => NO IMPORTER => NO TARGET
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-config_template (DATA) => NO IMPORTER => NO TARGET
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+config_template => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-console_port_template_count (DATA) => NO IMPORTER => NO TARGET
-console_server_port_template_count (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-default_platform (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => NO IMPORTER => NO TARGET
-device_bay_template_count (DATA) => NO IMPORTER => NO TARGET
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-front_port_template_count (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-interface_template_count (DATA) => NO IMPORTER => NO TARGET
-inventory_item_template_count (DATA) => NO IMPORTER => NO TARGET
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-module_bay_template_count (DATA) => NO IMPORTER => NO TARGET
-part_number (DATA) => value_importer => part_number (CharField)
-power_outlet_template_count (DATA) => NO IMPORTER => NO TARGET
-power_port_template_count (DATA) => NO IMPORTER => NO TARGET
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-rear_port_template_count (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
-* dcim.frontport => dcim.frontport *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-rear_port (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-* dcim.interface => dcim.interface *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-parent (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.inventoryitemrole => dcim.inventoryitemrole *************************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemrole` not found
-* dcim.inventoryitemtemplate => dcim.inventoryitemtemplate *****************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-* dcim.location => dcim.location *******************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-parent (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_abs_weight => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+console_port_template_count => NO IMPORTER => NO TARGET
+console_server_port_template_count => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+default_platform => NO IMPORTER => NO TARGET
+description => NO IMPORTER => NO TARGET
+device_bay_template_count => NO IMPORTER => NO TARGET
+front_image => Disabled with reason: Import does not contain images
+front_port_template_count => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+interface_template_count => NO IMPORTER => NO TARGET
+inventory_item_template_count => NO IMPORTER => NO TARGET
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+module_bay_template_count => NO IMPORTER => NO TARGET
+part_number => value_importer => part_number (CharField)
+power_outlet_template_count => NO IMPORTER => NO TARGET
+power_port_template_count => NO IMPORTER => NO TARGET
+rear_image => Disabled with reason: Import does not contain images
+rear_port_template_count => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-* dcim.module => dcim.module ***********************************************************************
-    Disable reason: Nautobot content type: `dcim.module` not found
-* dcim.modulebay => dcim.modulebay *****************************************************************
-    Disable reason: Nautobot content type: `dcim.modulebay` not found
-* dcim.modulebaytemplate => dcim.modulebaytemplate *************************************************
-    Disable reason: Nautobot content type: `dcim.modulebaytemplate` not found
-* dcim.moduletype => dcim.moduletype ***************************************************************
-    Disable reason: Nautobot content type: `dcim.moduletype` not found
-* dcim.platform => dcim.platform *******************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.powerfeed => dcim.powerfeed *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.poweroutlet => dcim.poweroutlet *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-power_port (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-* dcim.powerpanel => dcim.powerpanel ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-* dcim.powerport => dcim.powerport *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.rack => dcim.rack ***************************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* dcim.rackreservation => dcim.rackreservation *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-units (CUSTOM) => units_importer => units (JSONField)
-* dcim.rackrole => extras.role *********************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.rearport => dcim.rearport *******************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.region => dcim.location *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.virtualchassis => dcim.virtualchassis *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.virtualdevicecontext => dcim.virtualdevicecontext *******************************************
-    Disable reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.bookmark => extras.bookmark ***************************************************************
-    Disable reason: Nautobot content type: `extras.bookmark` not found
-* extras.branch => extras.branch *******************************************************************
-    Disable reason: Nautobot content type: `extras.branch` not found
-* extras.cachedvalue => extras.cachedvalue *********************************************************
-    Disable reason: Nautobot content type: `extras.cachedvalue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
-* extras.configtemplate => extras.configtemplate ***************************************************
-    Disable reason: Nautobot content type: `extras.configtemplate` not found
+_name => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (DATA) (CUSTOM) => choices_importer => Custom Target
-choices (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-group_name (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_cloneable (DATA) => NO IMPORTER => NO TARGET
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-object_type (DATA) => NO IMPORTER => NO TARGET
-required (DATA) => value_importer => required (BooleanField)
-search_weight (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-ui_visibility (DATA) => NO IMPORTER => NO TARGET
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.dashboard => extras.dashboard *************************************************************
-    Disable reason: Nautobot content type: `extras.dashboard` not found
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+choice_set => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+group_name => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+is_cloneable => NO IMPORTER => NO TARGET
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+object_type => NO IMPORTER => NO TARGET
+required => value_importer => required (BooleanField)
+search_weight => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+ui_visibility => NO IMPORTER => NO TARGET
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.journalentry => extras.note ***************************************************************
-assigned_object_id (DATA) => relation_and_type_importer => assigned_object_id (UUIDField)
-assigned_object_type (DATA) => relation_and_type_importer => assigned_object_type_id (ForeignKey)
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-created_by (DATA) => NO IMPORTER => NO TARGET
-custom_field_data (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-kind (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
+assigned_object_id => relation_and_type_importer => assigned_object_id (UUIDField)
+assigned_object_type => relation_and_type_importer => assigned_object_type_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+created_by => NO IMPORTER => NO TARGET
+custom_field_data => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+kind => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
 * extras.objectchange => extras.objectchange *******************************************************
-action (DATA) => value_importer => action (CharField)
-changed_object_id (DATA) => relation_and_type_importer => changed_object_id (UUIDField)
-changed_object_type (DATA) => relation_and_type_importer => changed_object_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_repr (DATA) => value_importer => object_repr (CharField)
-postchange_data (DATA) (CUSTOM) => json_importer => object_data (JSONField)
-prechange_data (DATA) => NO IMPORTER => NO TARGET
-related_object_id (DATA) => relation_and_type_importer => related_object_id (UUIDField)
-related_object_type (DATA) => relation_and_type_importer => related_object_type_id (ForeignKey)
-request_id (DATA) => uuid_importer => request_id (UUIDField)
-time (DATA) (CUSTOM) => datetime_importer => time (DateTimeField)
-user (DATA) => relation_importer => user_id (ForeignKey)
-user_name (DATA) => value_importer => user_name (CharField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.reportmodule => extras.reportmodule *******************************************************
-    Disable reason: Nautobot content type: `extras.reportmodule` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.savedfilter => extras.savedfilter *********************************************************
-    Disable reason: Nautobot content type: `extras.savedfilter` not found
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.scriptmodule => extras.scriptmodule *******************************************************
-    Disable reason: Nautobot content type: `extras.scriptmodule` not found
-* extras.stagedchange => extras.stagedchange *******************************************************
-    Disable reason: Nautobot content type: `extras.stagedchange` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
-* extras.tag => extras.tag *************************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (CUSTOM) => tagged_object_importer => content_type_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (CUSTOM) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.aggregate => ipam.prefix ********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.asnrange => ipam.asnrange *******************************************************************
-    Disable reason: Nautobot content type: `ipam.asnrange` not found
+action => value_importer => action (CharField)
+changed_object_id => relation_and_type_importer => changed_object_id (UUIDField)
+changed_object_type => relation_and_type_importer => changed_object_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_repr => value_importer => object_repr (CharField)
+postchange_data => json_importer => object_data (JSONField)
+prechange_data => NO IMPORTER => NO TARGET
+related_object_id => relation_and_type_importer => related_object_id (UUIDField)
+related_object_type => relation_and_type_importer => related_object_type_id (ForeignKey)
+request_id => uuid_importer => request_id (UUIDField)
+time => datetime_importer => time (DateTimeField)
+user => relation_importer => user_id (ForeignKey)
+user_name => value_importer => user_name (CharField)
 * ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-auth_key (DATA) => NO IMPORTER => NO TARGET
-auth_type (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group_id (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-protocol (DATA) => value_importer => protocol (CharField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-* ipam.ipaddress => ipam.ipaddress *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
-* ipam.l2vpn => ipam.l2vpn *************************************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpn` not found
-* ipam.l2vpntermination => ipam.l2vpntermination ***************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpntermination` not found
-* ipam.prefix => ipam.prefix ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.rir => ipam.rir *****************************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.routetarget => ipam.routetarget *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.servicetemplate => ipam.servicetemplate *****************************************************
-    Disable reason: Nautobot content type: `ipam.servicetemplate` not found
-* ipam.vlan => ipam.vlan ***************************************************************************
-group (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.vlangroup => ipam.vlangroup *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.vrf => ipam.vrf *****************************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+auth_key => NO IMPORTER => NO TARGET
+auth_type => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group_id => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+protocol => value_importer => protocol (CharField)
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.netboxgroup => users.netboxgroup ***********************************************************
-    Disable reason: Nautobot content type: `users.netboxgroup` not found
-* users.netboxuser => users.netboxuser *************************************************************
-    Disable reason: Nautobot content type: `users.netboxuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
-* virtualization.cluster => virtualization.cluster *************************************************
-group (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (CUSTOM) => location_importer => location_id (ForeignKey)
-type (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
-* virtualization.clustergroup => virtualization.clustergroup ***************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* virtualization.clustertype => virtualization.clustertype *****************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-role (CUSTOM) => relation_importer => role_id (RoleField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* virtualization.vminterface => virtualization.vminterface *****************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-parent (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 = End of Import Summary. ===========================================================================

--- a/nautobot_netbox_importer/tests/fixtures/3.6/summary.json
+++ b/nautobot_netbox_importer/tests/fixtures/3.6/summary.json
@@ -31,8 +31,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -64,8 +65,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -76,8 +78,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -88,8 +91,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 }
@@ -119,8 +124,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -152,8 +158,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "date_joined",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -164,8 +171,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "email",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -176,8 +184,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "first_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -188,8 +197,9 @@
                     "nautobot_can_import": true,
                     "importer": "identifiers_importer",
                     "definition": "groups",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -200,8 +210,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -212,8 +223,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_active",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -224,8 +236,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_staff",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -236,8 +249,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_superuser",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -248,8 +262,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -260,8 +276,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "last_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -272,8 +289,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Should not be attempted to migrate"
                 },
@@ -284,8 +303,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Permissions import is not implemented yet"
                 },
@@ -296,8 +317,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "username",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -327,8 +349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "cid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -339,8 +362,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -351,8 +375,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "commit_rate",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -363,8 +388,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -375,8 +401,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -387,8 +414,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -399,8 +427,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -411,8 +441,9 @@
                     "nautobot_can_import": true,
                     "importer": "date_importer",
                     "definition": "install_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -423,8 +454,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -435,8 +467,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -447,8 +480,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "provider_account",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -459,8 +493,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -471,8 +507,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -483,8 +520,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_a",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -495,8 +534,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "termination_date",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -507,8 +547,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_termination_z",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -519,8 +561,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -550,8 +594,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -562,8 +607,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -574,8 +620,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "circuit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -586,8 +633,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -598,8 +646,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -610,8 +659,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -622,8 +672,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -634,8 +686,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -646,8 +699,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -658,8 +712,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -670,8 +725,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "port_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -682,8 +738,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "pp_info",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -694,8 +751,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider_network",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -705,9 +763,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -718,8 +777,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -730,8 +791,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "term_side",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -742,8 +804,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "upstream_speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -754,8 +817,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "xconnect_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -785,8 +849,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -797,8 +862,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -809,8 +875,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -821,8 +888,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -833,8 +902,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -845,8 +915,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -857,8 +928,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -888,8 +960,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -900,8 +973,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -912,8 +986,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -924,8 +999,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -936,8 +1012,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -948,8 +1025,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -960,8 +1039,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -972,8 +1052,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -984,8 +1065,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1015,8 +1097,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1027,8 +1110,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1039,8 +1123,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1051,8 +1136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1063,8 +1149,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1075,8 +1163,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1087,8 +1176,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1099,8 +1189,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "provider",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1111,8 +1202,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "service_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1145,8 +1237,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_mapper_importer",
                     "definition": "define_app_label",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1157,8 +1251,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1169,8 +1264,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1200,8 +1296,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1212,8 +1309,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1224,8 +1322,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1236,8 +1335,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1248,8 +1348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1260,8 +1361,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1272,8 +1374,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1284,8 +1388,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1296,8 +1401,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1308,8 +1414,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "length",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1320,8 +1427,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "length_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1332,8 +1440,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -1344,8 +1454,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1356,8 +1467,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1387,8 +1499,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1418,8 +1531,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1430,8 +1544,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_location",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1442,8 +1557,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1454,8 +1570,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1466,8 +1583,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1478,8 +1597,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1490,8 +1610,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_a_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1502,8 +1623,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1514,8 +1636,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_and_type_importer",
                     "definition": "termination_b_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1545,8 +1668,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1557,8 +1681,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1569,8 +1694,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1581,8 +1707,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1593,8 +1720,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1605,8 +1733,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1617,8 +1746,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1629,8 +1759,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1641,8 +1772,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1653,8 +1786,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1665,8 +1799,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1677,8 +1812,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1689,8 +1825,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1701,8 +1838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1713,8 +1851,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1725,8 +1864,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1756,8 +1896,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1768,8 +1909,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1780,8 +1922,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1792,8 +1935,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -1804,8 +1948,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1816,8 +1962,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1828,8 +1975,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -1840,8 +1988,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1852,8 +2001,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1864,8 +2014,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1895,8 +2046,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1926,8 +2078,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -1957,8 +2110,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1969,8 +2123,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1981,8 +2136,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -1993,8 +2149,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2005,8 +2162,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2017,8 +2175,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2029,8 +2188,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2041,8 +2201,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2053,8 +2214,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2065,8 +2227,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2077,8 +2240,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "face",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2089,8 +2253,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2101,8 +2267,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2113,8 +2280,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2125,8 +2293,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2137,8 +2307,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2149,8 +2320,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2161,8 +2333,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2173,8 +2346,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2185,8 +2359,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2197,8 +2372,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2208,9 +2384,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2221,8 +2398,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2233,8 +2412,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2245,8 +2425,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2257,8 +2439,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -2269,8 +2453,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2281,8 +2466,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2293,8 +2479,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vc_priority",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2305,8 +2492,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_chassis",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2336,8 +2524,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2348,8 +2537,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2360,8 +2550,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2372,8 +2563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2384,8 +2576,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2396,8 +2589,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2408,8 +2603,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "installed_device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2420,8 +2616,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2432,8 +2629,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2444,8 +2642,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2475,8 +2674,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2487,8 +2687,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2499,8 +2700,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2511,8 +2713,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -2523,8 +2726,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2535,8 +2740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2547,8 +2753,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2559,8 +2766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2590,8 +2798,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -2602,8 +2812,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2614,8 +2825,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2626,8 +2838,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2638,8 +2851,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2650,8 +2864,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2662,8 +2878,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2674,8 +2891,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2686,8 +2904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2698,8 +2917,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vm_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2729,8 +2949,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2741,20 +2962,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "airflow",
-                    "from_data": true,
-                    "is_custom": false,
-                    "default_value": null,
-                    "disable_reason": ""
-                },
-                "color": {
-                    "name": "color",
-                    "nautobot_name": "color",
-                    "nautobot_internal_type": "NotFound",
-                    "nautobot_can_import": false,
-                    "importer": null,
-                    "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2765,8 +2975,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2777,8 +2988,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2789,8 +3001,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2801,8 +3014,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2813,8 +3027,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2825,8 +3041,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2837,8 +3056,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_full_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -2849,8 +3069,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -2861,8 +3082,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -2873,8 +3096,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "model",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2885,8 +3110,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "part_number",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2897,8 +3123,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Import does not contain images"
                 },
@@ -2909,8 +3137,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2921,8 +3150,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "subdevice_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2933,8 +3163,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -2945,8 +3176,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -2957,8 +3189,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -2988,8 +3221,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3000,8 +3234,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3012,8 +3247,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3024,8 +3260,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3036,8 +3273,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3048,8 +3286,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3060,8 +3299,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3072,8 +3312,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3084,8 +3325,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3096,8 +3339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3108,8 +3352,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3120,8 +3365,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3132,8 +3378,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3144,8 +3391,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3156,8 +3404,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3168,8 +3417,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3180,8 +3430,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3211,8 +3462,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3223,8 +3475,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3235,8 +3488,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3247,8 +3501,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3259,8 +3514,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3271,8 +3527,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3283,8 +3541,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3295,8 +3554,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3307,8 +3567,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3319,8 +3580,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3331,8 +3593,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rear_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3343,8 +3607,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "rear_port_position",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -3355,8 +3620,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3386,8 +3652,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3398,8 +3665,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3410,8 +3678,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3422,8 +3691,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3434,8 +3704,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3446,8 +3717,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3458,8 +3730,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3470,8 +3743,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3482,8 +3756,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3494,8 +3769,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "duplex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3506,8 +3782,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -3518,8 +3795,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3530,8 +3809,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3542,8 +3822,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "lag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3554,8 +3835,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3566,8 +3848,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3578,8 +3861,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3590,8 +3874,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -3602,8 +3887,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3614,8 +3900,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3626,8 +3913,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3638,8 +3926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3650,8 +3939,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3662,8 +3953,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3674,8 +3966,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3686,8 +3979,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3698,8 +3992,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_frequency",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3710,8 +4005,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_channel_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3722,8 +4018,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "rf_role",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3734,8 +4031,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "speed",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3746,8 +4044,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -3758,8 +4057,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3770,8 +4070,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "tx_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3782,8 +4083,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3794,8 +4096,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3806,8 +4109,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vdcs",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3818,8 +4122,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3830,8 +4135,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_lans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3842,8 +4148,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wireless_link",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3854,8 +4161,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "wwn",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -3885,8 +4193,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3897,8 +4206,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3909,8 +4219,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3921,8 +4232,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3933,8 +4245,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -3945,8 +4258,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3957,8 +4271,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3969,8 +4285,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -3981,8 +4298,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -3993,8 +4311,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mgmt_only",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4005,8 +4324,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4017,8 +4337,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4029,8 +4350,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4041,8 +4363,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "poe_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4053,8 +4376,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4084,8 +4408,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4096,8 +4421,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4108,8 +4434,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4120,8 +4447,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4132,8 +4460,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4199,8 +4528,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4211,8 +4541,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4223,8 +4554,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4235,8 +4567,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4247,8 +4581,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4259,8 +4594,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4271,8 +4608,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4283,8 +4622,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4295,8 +4635,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4307,8 +4648,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "_define_location_parent",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4319,8 +4662,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4331,8 +4676,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_parent_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4343,8 +4690,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4355,8 +4703,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -4367,8 +4717,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4379,8 +4730,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4410,8 +4763,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4422,8 +4776,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4434,8 +4790,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4446,8 +4803,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4458,8 +4816,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4470,8 +4829,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "nestable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -4482,8 +4842,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4494,8 +4855,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -4506,8 +4868,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -4537,8 +4900,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4549,8 +4913,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4561,8 +4926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4573,8 +4939,11 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4585,8 +4954,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4597,8 +4967,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4609,8 +4981,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4712,8 +5085,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4724,8 +5098,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4736,8 +5111,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4748,8 +5124,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4760,8 +5138,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4772,8 +5151,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "manufacturer",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "f5136724-0984-5e3b-b073-ea6d83116997",
                     "disable_reason": ""
                 },
@@ -4784,8 +5164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4796,8 +5177,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -4827,8 +5209,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4839,8 +5222,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "amperage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 20,
                     "disable_reason": ""
                 },
@@ -4851,8 +5235,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "available_power",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 0,
                     "disable_reason": ""
                 },
@@ -4863,8 +5248,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4875,8 +5261,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4887,8 +5274,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4899,8 +5287,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4911,8 +5300,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4923,8 +5313,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4935,8 +5326,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4947,8 +5340,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -4959,8 +5353,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4971,8 +5366,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "max_utilization",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 80,
                     "disable_reason": ""
                 },
@@ -4983,8 +5379,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -4995,8 +5392,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "phase",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "single-phase",
                     "disable_reason": ""
                 },
@@ -5007,8 +5405,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_panel",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5019,8 +5418,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5031,8 +5431,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -5043,8 +5445,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "supply",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "ac",
                     "disable_reason": ""
                 },
@@ -5055,8 +5458,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "primary",
                     "disable_reason": ""
                 },
@@ -5067,8 +5471,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "voltage",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 120,
                     "disable_reason": ""
                 }
@@ -5098,8 +5503,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5110,8 +5516,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5122,8 +5529,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5134,8 +5542,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5146,8 +5555,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5158,8 +5568,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5170,8 +5581,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5182,8 +5594,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5194,8 +5607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5206,8 +5620,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5218,8 +5634,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5230,8 +5647,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5242,8 +5660,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5254,8 +5673,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5266,8 +5686,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5278,8 +5699,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5290,8 +5712,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5321,8 +5744,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5333,8 +5757,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5345,8 +5770,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5357,8 +5783,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5369,8 +5796,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "feed_leg",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5381,8 +5809,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5393,8 +5823,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5405,8 +5836,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5417,8 +5849,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5429,8 +5862,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5441,8 +5875,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "power_port_template",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5453,8 +5889,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5484,8 +5921,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5496,8 +5934,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5508,8 +5947,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5520,8 +5960,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5532,8 +5973,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5544,8 +5987,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5556,8 +6000,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5568,8 +6014,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5579,9 +6026,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5592,8 +6040,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5623,8 +6073,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5635,8 +6086,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_path",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5647,8 +6099,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5659,8 +6112,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5671,8 +6125,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5683,8 +6138,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5695,8 +6151,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5707,8 +6164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5719,8 +6177,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5731,8 +6190,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5743,8 +6204,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5755,8 +6217,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5767,8 +6230,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5779,8 +6243,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5791,8 +6256,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5803,8 +6269,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5815,8 +6282,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -5846,8 +6314,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5858,8 +6327,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "allocated_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5870,8 +6340,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5882,8 +6353,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5894,8 +6366,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -5906,8 +6379,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5918,8 +6393,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5930,8 +6406,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -5942,8 +6419,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "maximum_draw",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5954,8 +6432,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5966,8 +6445,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -5978,8 +6458,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6009,8 +6490,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_max_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6021,8 +6503,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_abs_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6033,8 +6516,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6045,8 +6529,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "asset_tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6057,8 +6542,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6069,8 +6555,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6081,8 +6568,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6093,8 +6581,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "desc_units",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -6105,8 +6594,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6117,8 +6607,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6129,8 +6620,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6141,8 +6634,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6153,8 +6647,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6165,8 +6661,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6177,8 +6674,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mounting_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6189,8 +6687,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6201,8 +6700,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6213,8 +6713,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "outer_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6225,8 +6726,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "outer_width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6236,9 +6738,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6249,8 +6752,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6261,8 +6766,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "serial",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6273,8 +6779,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6285,8 +6793,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -6297,8 +6807,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6309,8 +6820,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6321,8 +6833,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "u_height",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 42,
                     "disable_reason": ""
                 },
@@ -6333,8 +6846,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6345,8 +6859,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "weight_unit",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6357,8 +6872,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "width",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 19,
                     "disable_reason": ""
                 }
@@ -6388,8 +6904,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6400,8 +6917,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6412,8 +6930,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6424,8 +6943,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6436,8 +6956,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6448,8 +6970,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6460,8 +6983,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rack",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6472,8 +6996,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6484,8 +7009,10 @@
                     "nautobot_can_import": true,
                     "importer": "units_importer",
                     "definition": "_define_units",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6496,8 +7023,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "user",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6527,8 +7055,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -6539,8 +7069,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6551,8 +7082,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6563,8 +7095,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6575,8 +7108,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6587,8 +7121,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6599,8 +7135,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6611,8 +7148,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6623,8 +7161,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6654,8 +7193,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6666,8 +7206,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cable",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6678,8 +7219,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "cable_end",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6690,8 +7232,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6702,8 +7245,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6714,8 +7258,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6726,8 +7271,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6738,8 +7284,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6750,8 +7297,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6762,8 +7311,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6774,8 +7324,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6786,8 +7337,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_connected",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6798,8 +7350,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6810,8 +7363,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6822,8 +7376,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6834,8 +7389,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -6865,8 +7421,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6877,8 +7434,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6889,8 +7447,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6901,8 +7460,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6913,8 +7473,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "device_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "c40e8fa5-0254-5b8f-97da-19b227497d92",
                     "disable_reason": ""
                 },
@@ -6925,8 +7486,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6937,8 +7500,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6949,8 +7513,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -6961,8 +7526,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "module_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6973,8 +7539,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -6985,8 +7552,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "positions",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 1,
                     "disable_reason": ""
                 },
@@ -6997,8 +7565,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7028,8 +7597,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7040,8 +7610,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7052,8 +7623,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7064,8 +7636,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7076,8 +7650,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7088,8 +7663,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7100,8 +7677,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7112,8 +7691,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7124,8 +7704,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7136,8 +7717,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7148,8 +7730,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7160,8 +7744,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7172,8 +7757,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7184,8 +7770,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7215,8 +7803,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7227,8 +7816,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "asns",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7239,8 +7829,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7251,8 +7842,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7263,8 +7855,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7275,8 +7868,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7287,8 +7881,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "facility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7299,8 +7894,10 @@
                     "nautobot_can_import": true,
                     "importer": "site_group_importer",
                     "definition": "_define_site_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7311,8 +7908,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7323,8 +7922,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7335,8 +7935,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "latitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7347,8 +7948,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7359,8 +7961,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7371,8 +7974,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "longitude",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7383,8 +7987,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7395,8 +8000,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "physical_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7407,8 +8013,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7419,8 +8027,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7431,8 +8040,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "shipping_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7443,8 +8053,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7455,8 +8066,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -7467,8 +8080,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7479,8 +8093,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "time_zone",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7491,8 +8106,9 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7522,8 +8138,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7534,8 +8151,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7546,8 +8164,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7558,8 +8177,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7570,8 +8190,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7582,8 +8204,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7594,8 +8217,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7606,8 +8231,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7618,8 +8245,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7630,8 +8258,9 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -7642,8 +8271,10 @@
                     "nautobot_can_import": true,
                     "importer": "constant_importer",
                     "definition": "define_constant",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7654,8 +8285,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -7666,8 +8299,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7678,8 +8312,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -7709,8 +8345,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7721,8 +8358,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7733,8 +8371,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7745,8 +8384,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7757,8 +8397,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "domain",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7769,8 +8410,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7781,8 +8424,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -7793,8 +8437,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "master",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7805,8 +8450,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7908,8 +8554,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -7957,8 +8604,10 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choice_set",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7969,8 +8618,9 @@
                     "nautobot_can_import": null,
                     "importer": "choices_importer",
                     "definition": "define_choices",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7981,8 +8631,10 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -7993,8 +8645,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8005,8 +8658,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "default",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8017,8 +8671,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8029,8 +8684,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "filter_logic",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "loose",
                     "disable_reason": ""
                 },
@@ -8041,8 +8697,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "group_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8053,8 +8710,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8065,8 +8724,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "label",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8077,8 +8737,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8089,8 +8750,10 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "key",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8101,8 +8764,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8113,8 +8777,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "required",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -8125,8 +8790,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "search_weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8137,8 +8803,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "text",
                     "disable_reason": ""
                 },
@@ -8149,8 +8816,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "ui_visibility",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8161,8 +8829,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_maximum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8173,8 +8842,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "validation_minimum",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8185,8 +8855,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "validation_regex",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8197,8 +8868,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": 100,
                     "disable_reason": ""
                 }
@@ -8228,8 +8900,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "custom_field",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8240,8 +8913,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8252,8 +8926,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "value",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8301,8 +8976,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8332,8 +9008,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8363,8 +9040,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8394,8 +9072,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8425,8 +9104,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8456,8 +9136,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8468,8 +9149,9 @@
                     "nautobot_can_import": true,
                     "importer": "json_importer",
                     "definition": "object_data",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8480,8 +9162,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "define_force",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8529,8 +9212,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8541,8 +9225,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8628,8 +9313,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8640,8 +9326,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8652,8 +9339,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "CACHE"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8683,8 +9371,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -8695,8 +9384,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8707,8 +9397,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8719,8 +9410,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8731,8 +9423,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8743,8 +9437,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8755,8 +9450,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8767,8 +9463,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8798,8 +9495,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "content_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8810,8 +9509,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8822,8 +9523,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "_define_tagged_object",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8834,8 +9537,10 @@
                     "nautobot_can_import": true,
                     "importer": "tagged_object_importer",
                     "definition": "tag",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8865,8 +9570,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -8896,8 +9602,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8908,8 +9615,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8920,8 +9628,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8932,8 +9641,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "date_added",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8944,8 +9654,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8956,8 +9667,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8968,8 +9681,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -8980,8 +9694,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -8992,8 +9707,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "rir",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9004,8 +9720,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9016,8 +9733,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9065,8 +9783,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9077,8 +9796,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 }
@@ -9126,8 +9846,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9138,8 +9859,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9150,8 +9872,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "assigned_object_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9162,8 +9885,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9174,8 +9898,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9186,8 +9911,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9198,8 +9924,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9210,8 +9937,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "dns_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9222,8 +9950,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9234,8 +9964,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9246,8 +9977,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "nat_inside",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9258,8 +9990,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9270,8 +10004,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9282,8 +10018,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9294,8 +10031,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9379,8 +10117,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_children",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9391,8 +10130,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_depth",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9403,8 +10143,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9415,8 +10156,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9427,8 +10169,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9439,8 +10182,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9451,8 +10195,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9463,8 +10209,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "is_pool",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9475,8 +10222,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9487,8 +10235,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9499,8 +10248,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "mark_utilized",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9511,8 +10261,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "prefix",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9522,9 +10273,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9535,8 +10287,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9547,8 +10301,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9559,8 +10315,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -9571,8 +10329,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9583,8 +10342,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9595,8 +10355,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9626,8 +10387,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9638,8 +10400,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9650,8 +10413,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9662,8 +10426,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9674,8 +10440,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "is_private",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": false,
                     "disable_reason": ""
                 },
@@ -9686,8 +10453,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9698,8 +10466,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9710,8 +10479,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9741,8 +10511,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "color",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": "9e9e9e",
                     "disable_reason": ""
                 },
@@ -9753,8 +10524,9 @@
                     "nautobot_can_import": true,
                     "importer": "content_types_importer",
                     "definition": "content_types",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9765,8 +10537,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9777,8 +10550,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9789,8 +10563,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9801,8 +10576,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9813,8 +10590,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9825,8 +10603,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9837,8 +10616,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9849,8 +10629,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "weight",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9880,8 +10661,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9892,8 +10674,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9904,8 +10687,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9916,8 +10700,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9928,8 +10713,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9940,8 +10727,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -9952,8 +10740,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -9964,8 +10753,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -9995,8 +10785,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10044,8 +10835,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10056,8 +10848,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10068,8 +10861,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10080,8 +10874,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10092,8 +10887,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vlan_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10104,8 +10901,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10116,8 +10915,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10128,8 +10928,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10140,8 +10941,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10151,9 +10953,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10164,8 +10967,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10176,8 +10981,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10188,8 +10995,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -10200,8 +11009,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10212,8 +11022,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10243,8 +11054,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10255,8 +11067,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10267,8 +11080,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10279,8 +11093,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10291,8 +11107,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10303,8 +11120,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "max_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10315,8 +11133,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "min_vid",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10327,8 +11146,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10339,8 +11159,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_id",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10351,8 +11172,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "scope_type",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10363,8 +11185,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10394,8 +11217,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10406,8 +11230,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10418,8 +11243,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10430,8 +11256,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10442,8 +11269,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "enforce_unique",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10454,8 +11282,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "export_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10466,8 +11295,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10478,8 +11309,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "import_targets",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10490,8 +11322,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -10502,8 +11335,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10514,8 +11348,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "rd",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10526,8 +11361,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10629,8 +11465,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "session_key",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10660,8 +11497,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10691,8 +11529,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10722,8 +11561,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10753,8 +11593,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10784,8 +11625,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10815,8 +11657,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10846,8 +11689,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -10949,8 +11793,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10961,8 +11806,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10973,8 +11819,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10985,8 +11832,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -10997,8 +11845,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11009,8 +11859,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11021,8 +11873,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11033,8 +11886,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11045,8 +11899,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11076,8 +11931,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11088,8 +11944,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11100,8 +11957,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11112,8 +11970,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11124,8 +11984,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11136,8 +11997,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11148,8 +12011,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11160,8 +12025,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11172,8 +12038,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11184,8 +12051,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 },
@@ -11196,8 +12065,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11208,8 +12078,10 @@
                     "nautobot_can_import": null,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Tree fields doesn't need to be imported"
                 }
@@ -11239,8 +12111,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11288,8 +12161,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11319,8 +12193,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11368,8 +12243,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11380,8 +12256,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11392,8 +12269,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11404,8 +12282,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11416,8 +12295,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_group",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11428,8 +12309,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11440,8 +12323,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11452,8 +12336,9 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "define_location",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11464,8 +12349,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11475,9 +12361,10 @@
                     "nautobot_internal_type": "ForeignKey",
                     "nautobot_can_import": true,
                     "importer": "location_importer",
-                    "definition": "location_id",
-                    "from_data": false,
-                    "is_custom": true,
+                    "definition": "region",
+                    "sources": [
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11488,8 +12375,10 @@
                     "nautobot_can_import": true,
                     "importer": "location_importer",
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA",
+                        "SIBLING"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11500,8 +12389,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11512,8 +12402,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11524,8 +12415,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster_type",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11555,8 +12448,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11567,8 +12461,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11579,8 +12474,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11591,8 +12487,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11603,8 +12501,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11615,8 +12514,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11627,8 +12527,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11658,8 +12559,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11670,8 +12572,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11682,8 +12585,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11694,8 +12598,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11706,8 +12612,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11718,8 +12625,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11730,8 +12638,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "slug",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -11761,8 +12670,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11773,8 +12683,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "cluster",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11785,8 +12696,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "comments",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11797,8 +12709,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11809,8 +12722,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11821,8 +12735,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11833,8 +12748,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "device",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11845,8 +12761,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "disk",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11857,8 +12774,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11869,8 +12788,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -11881,8 +12801,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "local_context_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11893,8 +12814,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "memory",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11905,8 +12827,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11917,8 +12840,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "platform",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11929,8 +12853,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip4",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11941,8 +12866,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "primary_ip6",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11953,8 +12879,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "define_relation",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11965,8 +12893,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "site",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -11977,8 +12906,10 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -11989,8 +12920,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "tenant",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12001,8 +12933,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "vcpus",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }
@@ -12032,8 +12965,9 @@
                     "nautobot_can_import": false,
                     "importer": null,
                     "definition": "_name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12044,8 +12978,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "bridge",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12056,8 +12991,9 @@
                     "nautobot_can_import": true,
                     "importer": "datetime_importer",
                     "definition": "created",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12068,8 +13004,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "custom_field_data",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12080,8 +13017,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "description",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12092,8 +13030,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "enabled",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": true,
                     "disable_reason": ""
                 },
@@ -12104,8 +13043,10 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": "id",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12116,8 +13057,9 @@
                     "nautobot_can_import": true,
                     "importer": null,
                     "definition": null,
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": "Last updated field is updated with each write"
                 },
@@ -12128,8 +13070,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mac_address",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12140,8 +13083,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "mode",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12152,8 +13096,9 @@
                     "nautobot_can_import": true,
                     "importer": "integer_importer",
                     "definition": "mtu",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12164,8 +13109,9 @@
                     "nautobot_can_import": true,
                     "importer": "value_importer",
                     "definition": "name",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12176,8 +13122,10 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "parent_interface",
-                    "from_data": true,
-                    "is_custom": true,
+                    "sources": [
+                        "CUSTOM",
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12188,8 +13136,9 @@
                     "nautobot_can_import": true,
                     "importer": "status_importer",
                     "definition": "status",
-                    "from_data": false,
-                    "is_custom": true,
+                    "sources": [
+                        "AUTO"
+                    ],
                     "default_value": "623acb70-22ce-5f69-bd7e-76bc921aa6c4",
                     "disable_reason": ""
                 },
@@ -12200,8 +13149,9 @@
                     "nautobot_can_import": true,
                     "importer": "uuids_importer",
                     "definition": "tagged_vlans",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12212,8 +13162,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "untagged_vlan",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12224,8 +13175,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "virtual_machine",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 },
@@ -12236,8 +13188,9 @@
                     "nautobot_can_import": true,
                     "importer": "relation_importer",
                     "definition": "vrf",
-                    "from_data": true,
-                    "is_custom": false,
+                    "sources": [
+                        "DATA"
+                    ],
                     "default_value": null,
                     "disable_reason": ""
                 }

--- a/nautobot_netbox_importer/tests/fixtures/3.6/summary.txt
+++ b/nautobot_netbox_importer/tests/fixtures/3.6/summary.txt
@@ -120,56 +120,15 @@ fcb61481-0da8-5412-b68b-2463016a017d P2-12B | ['Rack R204 (Row 2) and power pane
 Total validation issues: 48
 - Content Types Mapping Deviations: ----------------------------------------------------------------
   Mapping deviations from source content type to Nautobot content type
-admin.logentry => admin.logentry | Disabled with reason: Not directly used in Nautobot.
-auth.permission => auth.permission | Disabled with reason: Handled via a Nautobot model and may not be a 1 to 1.
 auth.user => users.user
-dcim.cablepath => dcim.cablepath | Disabled with reason: Recreated in Nautobot on signal when circuit termination is created
 dcim.cabletermination EXTENDS dcim.cable => dcim.cable
 dcim.devicerole => extras.role
-dcim.inventoryitemrole => dcim.inventoryitemrole | Disabled with reason: Nautobot content type: `dcim.inventoryitemrole` not found
-dcim.inventoryitemtemplate => dcim.inventoryitemtemplate | Disabled with reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
-dcim.module => dcim.module | Disabled with reason: Nautobot content type: `dcim.module` not found
-dcim.modulebay => dcim.modulebay | Disabled with reason: Nautobot content type: `dcim.modulebay` not found
-dcim.modulebaytemplate => dcim.modulebaytemplate | Disabled with reason: Nautobot content type: `dcim.modulebaytemplate` not found
-dcim.moduletype => dcim.moduletype | Disabled with reason: Nautobot content type: `dcim.moduletype` not found
 dcim.rackrole => extras.role
 dcim.region => dcim.location
 dcim.site => dcim.location
 dcim.sitegroup => dcim.locationtype
-dcim.virtualdevicecontext => dcim.virtualdevicecontext | Disabled with reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-django_rq.queue => django_rq.queue | Disabled with reason: Nautobot content type: `django_rq.queue` not found
-extras.branch => extras.branch | Disabled with reason: Nautobot content type: `extras.branch` not found
-extras.cachedvalue => extras.cachedvalue | Disabled with reason: Nautobot content type: `extras.cachedvalue` not found
-extras.configrevision => extras.configrevision | Disabled with reason: Nautobot content type: `extras.configrevision` not found
-extras.customfieldchoiceset => extras.customfieldchoiceset | Disabled with reason: Nautobot content type: `extras.customfieldchoiceset` not found
-extras.journalentry => extras.note
-extras.report => extras.report | Disabled with reason: Nautobot content type: `extras.report` not found
-extras.savedfilter => extras.savedfilter | Disabled with reason: Nautobot content type: `extras.savedfilter` not found
-extras.script => extras.script | Disabled with reason: Nautobot content type: `extras.script` not found
-extras.stagedchange => extras.stagedchange | Disabled with reason: Nautobot content type: `extras.stagedchange` not found
 ipam.aggregate => ipam.prefix
-ipam.asn => ipam.asn | Disabled with reason: Nautobot content type: `ipam.asn` not found
-ipam.fhrpgroup => dcim.interfaceredundancygroup
-ipam.fhrpgroupassignment => ipam.fhrpgroupassignment | Disabled with reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
-ipam.iprange => ipam.iprange | Disabled with reason: Nautobot content type: `ipam.iprange` not found
-ipam.l2vpn => ipam.l2vpn | Disabled with reason: Nautobot content type: `ipam.l2vpn` not found
-ipam.l2vpntermination => ipam.l2vpntermination | Disabled with reason: Nautobot content type: `ipam.l2vpntermination` not found
 ipam.role => extras.role
-ipam.servicetemplate => ipam.servicetemplate | Disabled with reason: Nautobot content type: `ipam.servicetemplate` not found
-secrets.secret => secrets.secret | Disabled with reason: Nautobot content type: `secrets.secret` not found
-secrets.secretrole => secrets.secretrole | Disabled with reason: Nautobot content type: `secrets.secretrole` not found
-secrets.sessionkey => secrets.sessionkey | Disabled with reason: Nautobot content type: `secrets.sessionkey` not found
-secrets.userkey => secrets.userkey | Disabled with reason: Nautobot content type: `secrets.userkey` not found
-sessions.session => sessions.session | Disabled with reason: Nautobot has own sessions, sessions should never cross apps.
-tenancy.contact => tenancy.contact | Disabled with reason: Nautobot content type: `tenancy.contact` not found
-tenancy.contactassignment => tenancy.contactassignment | Disabled with reason: Nautobot content type: `tenancy.contactassignment` not found
-tenancy.contactgroup => tenancy.contactgroup | Disabled with reason: Nautobot content type: `tenancy.contactgroup` not found
-tenancy.contactrole => tenancy.contactrole | Disabled with reason: Nautobot content type: `tenancy.contactrole` not found
-users.adminuser => users.adminuser | Disabled with reason: Nautobot content type: `users.adminuser` not found
-users.userconfig => users.userconfig | Disabled with reason: May not have a 1 to 1 translation to Nautobot.
-wireless.wirelesslan => wireless.wirelesslan | Disabled with reason: Nautobot content type: `wireless.wirelesslan` not found
-wireless.wirelesslangroup => wireless.wirelesslangroup | Disabled with reason: Nautobot content type: `wireless.wirelesslangroup` not found
-wireless.wirelesslink => wireless.wirelesslink | Disabled with reason: Nautobot content type: `wireless.wirelesslink` not found
 - Content Types Back Mapping: ----------------------------------------------------------------------
   Back mapping deviations from Nautobot content type to the source content type
 users.user => auth.user
@@ -177,997 +136,809 @@ dcim.cable => dcim.cabletermination
 extras.role => Ambiguous
 dcim.location => Ambiguous
 dcim.locationtype => dcim.sitegroup
-extras.note => extras.journalentry
 ipam.prefix => ipam.aggregate
-dcim.interfaceredundancygroup => ipam.fhrpgroup
 - Detailed Fields Mapping: -------------------------------------------------------------------------
-* admin.logentry => admin.logentry *****************************************************************
-    Disable reason: Not directly used in Nautobot.
 * auth.group => auth.group *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-name (DATA) => value_importer => name (CharField)
-permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-* auth.permission => auth.permission ***************************************************************
-    Disable reason: Handled via a Nautobot model and may not be a 1 to 1.
+name => value_importer => name (CharField)
+permissions => Disabled with reason: Permissions import is not implemented yet
 * auth.user => users.user **************************************************************************
-date_joined (DATA) => datetime_importer => date_joined (DateTimeField)
-email (DATA) => value_importer => email (CharField)
-first_name (DATA) => value_importer => first_name (CharField)
-groups (DATA) => identifiers_importer => groups (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-is_active (DATA) => value_importer => is_active (BooleanField)
-is_staff (DATA) => value_importer => is_staff (BooleanField)
-is_superuser (DATA) => value_importer => is_superuser (BooleanField)
-last_login (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-last_name (DATA) => value_importer => last_name (CharField)
-password (DATA) (CUSTOM) => Disabled with reason: Should not be attempted to migrate
-user_permissions (DATA) (CUSTOM) => Disabled with reason: Permissions import is not implemented yet
-username (DATA) => value_importer => username (CharField)
+date_joined => datetime_importer => date_joined (DateTimeField)
+email => value_importer => email (CharField)
+first_name => value_importer => first_name (CharField)
+groups => identifiers_importer => groups (ManyToManyField)
+is_active => value_importer => is_active (BooleanField)
+is_staff => value_importer => is_staff (BooleanField)
+is_superuser => value_importer => is_superuser (BooleanField)
+last_login => Disabled with reason: Should not be attempted to migrate
+last_name => value_importer => last_name (CharField)
+password => Disabled with reason: Should not be attempted to migrate
+user_permissions => Disabled with reason: Permissions import is not implemented yet
+username => value_importer => username (CharField)
 * circuits.circuit => circuits.circuit *************************************************************
-cid (DATA) => value_importer => cid (CharField)
-comments (DATA) => value_importer => comments (TextField)
-commit_rate (DATA) => integer_importer => commit_rate (PositiveIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-install_date (DATA) => date_importer => install_date (DateField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-provider_account (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-termination_a (DATA) (CUSTOM) => relation_importer => circuit_termination_a_id (ForeignKey)
-termination_date (DATA) => NO IMPORTER => NO TARGET
-termination_z (DATA) (CUSTOM) => relation_importer => circuit_termination_z_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => circuit_type_id (ForeignKey)
+cid => value_importer => cid (CharField)
+comments => value_importer => comments (TextField)
+commit_rate => integer_importer => commit_rate (PositiveIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+install_date => date_importer => install_date (DateField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+provider => relation_importer => provider_id (ForeignKey)
+provider_account => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+termination_a => relation_importer => circuit_termination_a_id (ForeignKey)
+termination_date => NO IMPORTER => NO TARGET
+termination_z => relation_importer => circuit_termination_z_id (ForeignKey)
+type => relation_importer => circuit_type_id (ForeignKey)
 * circuits.circuittermination => circuits.circuittermination ***************************************
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-circuit (DATA) => relation_importer => circuit_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-port_speed (DATA) => integer_importer => port_speed (PositiveIntegerField)
-pp_info (DATA) => value_importer => pp_info (CharField)
-provider_network (DATA) => relation_importer => provider_network_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-term_side (DATA) => value_importer => term_side (CharField)
-upstream_speed (DATA) => integer_importer => upstream_speed (PositiveIntegerField)
-xconnect_id (DATA) => value_importer => xconnect_id (CharField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+circuit => relation_importer => circuit_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+port_speed => integer_importer => port_speed (PositiveIntegerField)
+pp_info => value_importer => pp_info (CharField)
+provider_network => relation_importer => provider_network_id (ForeignKey)
+site => location_importer => location_id (ForeignKey)
+term_side => value_importer => term_side (CharField)
+upstream_speed => integer_importer => upstream_speed (PositiveIntegerField)
+xconnect_id => value_importer => xconnect_id (CharField)
 * circuits.circuittype => circuits.circuittype *****************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.provider => circuits.provider ***********************************************************
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * circuits.providernetwork => circuits.providernetwork *********************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-provider (DATA) => relation_importer => provider_id (ForeignKey)
-service_id (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+provider => relation_importer => provider_id (ForeignKey)
+service_id => NO IMPORTER => NO TARGET
 * contenttypes.contenttype => contenttypes.contenttype *********************************************
-app_label (DATA) (CUSTOM) => content_types_mapper_importer => app_label (CharField)
-id (CUSTOM) => uid_from_data => id (AutoField)
-model (DATA) => value_importer => model (CharField)
+app_label => content_types_mapper_importer => app_label (CharField)
+model => value_importer => model (CharField)
 * dcim.cable => dcim.cable *************************************************************************
-_abs_length (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => value_importer => color (CharField)
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-length (DATA) => integer_importer => length (PositiveSmallIntegerField)
-length_unit (DATA) => value_importer => length_unit (CharField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.cablepath => dcim.cablepath *****************************************************************
-    Disable reason: Recreated in Nautobot on signal when circuit termination is created
+_abs_length => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+length => integer_importer => length (PositiveSmallIntegerField)
+length_unit => value_importer => length_unit (CharField)
+status => status_importer => status_id (StatusField)
+tenant => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.cabletermination => dcim.cable **************************************************************
-_device (DATA) => NO IMPORTER => NO TARGET
-_location (DATA) => NO IMPORTER => NO TARGET
-_rack (DATA) => NO IMPORTER => NO TARGET
-_site (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-termination_a_id (DATA) => relation_and_type_importer => termination_a_id (UUIDField)
-termination_a_type (DATA) => relation_and_type_importer => termination_a_type_id (ForeignKey)
-termination_b_id (DATA) => relation_and_type_importer => termination_b_id (UUIDField)
-termination_b_type (DATA) => relation_and_type_importer => termination_b_type_id (ForeignKey)
+_device => NO IMPORTER => NO TARGET
+_location => NO IMPORTER => NO TARGET
+_rack => NO IMPORTER => NO TARGET
+_site => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+termination_a_id => relation_and_type_importer => termination_a_id (UUIDField)
+termination_a_type => relation_and_type_importer => termination_a_type_id (ForeignKey)
+termination_b_id => relation_and_type_importer => termination_b_id (UUIDField)
+termination_b_type => relation_and_type_importer => termination_b_type_id (ForeignKey)
 * dcim.consoleport => dcim.consoleport *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-speed (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+speed => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.consoleporttemplate => dcim.consoleporttemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
-* dcim.consoleserverport => dcim.consoleserverport *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* dcim.consoleserverporttemplate => dcim.consoleserverporttemplate *********************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.device => dcim.device ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device_role (CUSTOM) => relation_importer => role_id (RoleField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKey)
-face (DATA) => value_importer => face (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-position (DATA) => integer_importer => position (PositiveSmallIntegerField)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vc_position (DATA) => integer_importer => vc_position (PositiveSmallIntegerField)
-vc_priority (DATA) => integer_importer => vc_priority (PositiveSmallIntegerField)
-virtual_chassis (DATA) => relation_importer => virtual_chassis_id (ForeignKey)
+_name => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device_type => relation_importer => device_type_id (ForeignKey)
+face => value_importer => face (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+position => integer_importer => position (PositiveSmallIntegerField)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vc_position => integer_importer => vc_position (PositiveSmallIntegerField)
+vc_priority => integer_importer => vc_priority (PositiveSmallIntegerField)
+virtual_chassis => relation_importer => virtual_chassis_id (ForeignKey)
 * dcim.devicebay => dcim.devicebay *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-installed_device (DATA) => relation_importer => installed_device_id (OneToOneField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+installed_device => relation_importer => installed_device_id (OneToOneField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicebaytemplate => dcim.devicebaytemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
 * dcim.devicerole => extras.role *******************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-vm_role (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+vm_role => NO IMPORTER => NO TARGET
 * dcim.devicetype => dcim.devicetype ***************************************************************
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-airflow (DATA) => NO IMPORTER => NO TARGET
-color (CUSTOM) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-front_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_full_depth (DATA) => value_importer => is_full_depth (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-model (DATA) => value_importer => model (CharField)
-part_number (DATA) => value_importer => part_number (CharField)
-rear_image (DATA) (CUSTOM) => Disabled with reason: Import does not contain images
-slug (DATA) => NO IMPORTER => NO TARGET
-subdevice_role (DATA) => value_importer => subdevice_role (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
+_abs_weight => NO IMPORTER => NO TARGET
+airflow => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+front_image => Disabled with reason: Import does not contain images
+id => uid_from_data => id (UUIDField)
+is_full_depth => value_importer => is_full_depth (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+model => value_importer => model (CharField)
+part_number => value_importer => part_number (CharField)
+rear_image => Disabled with reason: Import does not contain images
+slug => NO IMPORTER => NO TARGET
+subdevice_role => value_importer => subdevice_role (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
 * dcim.frontport => dcim.frontport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) => relation_importer => rear_port_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.frontporttemplate => dcim.frontporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-rear_port (DATA) (CUSTOM) => relation_importer => rear_port_template_id (ForeignKey)
-rear_port_position (DATA) => integer_importer => rear_port_position (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+rear_port => relation_importer => rear_port_template_id (ForeignKey)
+rear_port_position => integer_importer => rear_port_position (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.interface => dcim.interface *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-duplex (DATA) => NO IMPORTER => NO TARGET
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-lag (DATA) => relation_importer => lag_id (ForeignKey)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-mode (DATA) => value_importer => mode (CharField)
-module (DATA) => NO IMPORTER => NO TARGET
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-rf_channel (DATA) => NO IMPORTER => NO TARGET
-rf_channel_frequency (DATA) => NO IMPORTER => NO TARGET
-rf_channel_width (DATA) => NO IMPORTER => NO TARGET
-rf_role (DATA) => NO IMPORTER => NO TARGET
-speed (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-tx_power (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-vdcs (DATA) => NO IMPORTER => NO TARGET
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-wireless_lans (DATA) => NO IMPORTER => NO TARGET
-wireless_link (DATA) => NO IMPORTER => NO TARGET
-wwn (DATA) => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+duplex => NO IMPORTER => NO TARGET
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+lag => relation_importer => lag_id (ForeignKey)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mark_connected => NO IMPORTER => NO TARGET
+mgmt_only => value_importer => mgmt_only (BooleanField)
+mode => value_importer => mode (CharField)
+module => NO IMPORTER => NO TARGET
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+rf_channel => NO IMPORTER => NO TARGET
+rf_channel_frequency => NO IMPORTER => NO TARGET
+rf_channel_width => NO IMPORTER => NO TARGET
+rf_role => NO IMPORTER => NO TARGET
+speed => NO IMPORTER => NO TARGET
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+tx_power => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+vdcs => NO IMPORTER => NO TARGET
+vrf => relation_importer => vrf_id (ForeignKey)
+wireless_lans => NO IMPORTER => NO TARGET
+wireless_link => NO IMPORTER => NO TARGET
+wwn => NO IMPORTER => NO TARGET
 * dcim.interfacetemplate => dcim.interfacetemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-enabled (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mgmt_only (DATA) => value_importer => mgmt_only (BooleanField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-poe_mode (DATA) => NO IMPORTER => NO TARGET
-poe_type (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-* dcim.inventoryitem => dcim.inventoryitem *********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.inventoryitemrole => dcim.inventoryitemrole *************************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemrole` not found
-* dcim.inventoryitemtemplate => dcim.inventoryitemtemplate *****************************************
-    Disable reason: Nautobot content type: `dcim.inventoryitemtemplate` not found
+_name => NO IMPORTER => NO TARGET
+bridge => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+enabled => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mgmt_only => value_importer => mgmt_only (BooleanField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+poe_mode => NO IMPORTER => NO TARGET
+poe_type => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
 * dcim.location => dcim.location *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => location_parent_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-site (DATA) => location_parent_importer => parent_id (TreeNodeForeignKey)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* dcim.locationtype => dcim.locationtype ***********************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (DATA) => value_importer => nestable (BooleanField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => location_parent_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+site => location_parent_importer => parent_id (TreeNodeForeignKey)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.manufacturer => dcim.manufacturer ***********************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-* dcim.module => dcim.module ***********************************************************************
-    Disable reason: Nautobot content type: `dcim.module` not found
-* dcim.modulebay => dcim.modulebay *****************************************************************
-    Disable reason: Nautobot content type: `dcim.modulebay` not found
-* dcim.modulebaytemplate => dcim.modulebaytemplate *************************************************
-    Disable reason: Nautobot content type: `dcim.modulebaytemplate` not found
-* dcim.moduletype => dcim.moduletype ***************************************************************
-    Disable reason: Nautobot content type: `dcim.moduletype` not found
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.platform => dcim.platform *******************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-manufacturer (DATA) => relation_importer => manufacturer_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+manufacturer => relation_importer => manufacturer_id (ForeignKey)
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.powerfeed => dcim.powerfeed *****************************************************************
-_path (DATA) => NO IMPORTER => NO TARGET
-amperage (DATA) => integer_importer => amperage (PositiveSmallIntegerField)
-available_power (DATA) => integer_importer => available_power (PositiveIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-max_utilization (DATA) => integer_importer => max_utilization (PositiveSmallIntegerField)
-name (DATA) => value_importer => name (CharField)
-phase (DATA) => value_importer => phase (CharField)
-power_panel (DATA) => relation_importer => power_panel_id (ForeignKey)
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-supply (DATA) => value_importer => supply (CharField)
-type (DATA) => value_importer => type (CharField)
-voltage (DATA) => integer_importer => voltage (SmallIntegerField)
+_path => NO IMPORTER => NO TARGET
+amperage => integer_importer => amperage (PositiveSmallIntegerField)
+available_power => integer_importer => available_power (PositiveIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+max_utilization => integer_importer => max_utilization (PositiveSmallIntegerField)
+name => value_importer => name (CharField)
+phase => value_importer => phase (CharField)
+power_panel => relation_importer => power_panel_id (ForeignKey)
+rack => relation_importer => rack_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+supply => value_importer => supply (CharField)
+type => value_importer => type (CharField)
+voltage => integer_importer => voltage (SmallIntegerField)
 * dcim.poweroutlet => dcim.poweroutlet *************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) => relation_importer => power_port_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.poweroutlettemplate => dcim.poweroutlettemplate *********************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-feed_leg (DATA) => value_importer => feed_leg (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-power_port (DATA) (CUSTOM) => relation_importer => power_port_template_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+feed_leg => value_importer => feed_leg (CharField)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+power_port => relation_importer => power_port_template_id (ForeignKey)
+type => value_importer => type (CharField)
 * dcim.powerpanel => dcim.powerpanel ***************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
 * dcim.powerport => dcim.powerport *****************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-_path (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+_path => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.powerporttemplate => dcim.powerporttemplate *************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-allocated_draw (DATA) => integer_importer => allocated_draw (PositiveSmallIntegerField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-maximum_draw (DATA) => integer_importer => maximum_draw (PositiveSmallIntegerField)
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+allocated_draw => integer_importer => allocated_draw (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+maximum_draw => integer_importer => maximum_draw (PositiveSmallIntegerField)
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+type => value_importer => type (CharField)
 * dcim.rack => dcim.rack ***************************************************************************
-_abs_max_weight (DATA) => NO IMPORTER => NO TARGET
-_abs_weight (DATA) => NO IMPORTER => NO TARGET
-_name (DATA) => NO IMPORTER => NO TARGET
-asset_tag (DATA) => value_importer => asset_tag (CharField)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-desc_units (DATA) => value_importer => desc_units (BooleanField)
-description (DATA) => NO IMPORTER => NO TARGET
-facility_id (DATA) => value_importer => facility_id (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (DATA) (CUSTOM) => location_importer => location_id (ForeignKey)
-max_weight (DATA) => NO IMPORTER => NO TARGET
-mounting_depth (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-outer_depth (DATA) => integer_importer => outer_depth (PositiveSmallIntegerField)
-outer_unit (DATA) => value_importer => outer_unit (CharField)
-outer_width (DATA) => integer_importer => outer_width (PositiveSmallIntegerField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-serial (DATA) => value_importer => serial (CharField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) => value_importer => type (CharField)
-u_height (DATA) => integer_importer => u_height (PositiveSmallIntegerField)
-weight (DATA) => NO IMPORTER => NO TARGET
-weight_unit (DATA) => NO IMPORTER => NO TARGET
-width (DATA) => integer_importer => width (PositiveSmallIntegerField)
+_abs_max_weight => NO IMPORTER => NO TARGET
+_abs_weight => NO IMPORTER => NO TARGET
+_name => NO IMPORTER => NO TARGET
+asset_tag => value_importer => asset_tag (CharField)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+desc_units => value_importer => desc_units (BooleanField)
+description => NO IMPORTER => NO TARGET
+facility_id => value_importer => facility_id (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+location => location_importer => location_id (ForeignKey)
+max_weight => NO IMPORTER => NO TARGET
+mounting_depth => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+outer_depth => integer_importer => outer_depth (PositiveSmallIntegerField)
+outer_unit => value_importer => outer_unit (CharField)
+outer_width => integer_importer => outer_width (PositiveSmallIntegerField)
+role => relation_importer => role_id (RoleField)
+serial => value_importer => serial (CharField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+type => value_importer => type (CharField)
+u_height => integer_importer => u_height (PositiveSmallIntegerField)
+weight => NO IMPORTER => NO TARGET
+weight_unit => NO IMPORTER => NO TARGET
+width => integer_importer => width (PositiveSmallIntegerField)
 * dcim.rackreservation => dcim.rackreservation *****************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-rack (DATA) => relation_importer => rack_id (ForeignKey)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-units (DATA) (CUSTOM) => units_importer => units (JSONField)
-user (DATA) => relation_importer => user_id (ForeignKey)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+rack => relation_importer => rack_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
+units => units_importer => units (JSONField)
+user => relation_importer => user_id (ForeignKey)
 * dcim.rackrole => extras.role *********************************************************************
-color (DATA) (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * dcim.rearport => dcim.rearport *******************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cable (DATA) => relation_importer => cable_id (ForeignKey)
-cable_end (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-device (DATA) => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mark_connected (DATA) => NO IMPORTER => NO TARGET
-module (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+cable => relation_importer => cable_id (ForeignKey)
+cable_end => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+device => relation_importer => device_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_connected => NO IMPORTER => NO TARGET
+module => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.rearporttemplate => dcim.rearporttemplate ***************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-color (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-device_type (DATA) => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-module_type (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-positions (DATA) => integer_importer => positions (PositiveSmallIntegerField)
-type (DATA) => value_importer => type (CharField)
+_name => NO IMPORTER => NO TARGET
+color => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+device_type => relation_importer => device_type_id (ForeignKeyWithAutoRelatedName)
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+module_type => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+positions => integer_importer => positions (PositiveSmallIntegerField)
+type => value_importer => type (CharField)
 * dcim.region => dcim.location *********************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-location_type (CUSTOM) => constant_importer => location_type_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-status (CUSTOM) => status_importer => status_id (StatusField)
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.site => dcim.location ***********************************************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-asns (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-facility (DATA) => value_importer => facility (CharField)
-group (DATA) (CUSTOM) => site_group_importer => location_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-latitude (DATA) => value_importer => latitude (DecimalField)
-level (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-longitude (DATA) => value_importer => longitude (DecimalField)
-name (DATA) => value_importer => name (CharField)
-physical_address (DATA) => value_importer => physical_address (TextField)
-region (DATA) (CUSTOM) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-shipping_address (DATA) => value_importer => shipping_address (TextField)
-slug (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-time_zone (DATA) => value_importer => time_zone (CharField)
-tree_id (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+_name => NO IMPORTER => NO TARGET
+asns => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+facility => value_importer => facility (CharField)
+group => site_group_importer => location_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+latitude => value_importer => latitude (DecimalField)
+longitude => value_importer => longitude (DecimalField)
+name => value_importer => name (CharField)
+physical_address => value_importer => physical_address (TextField)
+region => relation_importer => parent_id (TreeNodeForeignKey)
+shipping_address => value_importer => shipping_address (TextField)
+slug => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+time_zone => value_importer => time_zone (CharField)
 * dcim.sitegroup => dcim.locationtype **************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-nestable (CUSTOM) => constant_importer => nestable (BooleanField)
-parent (DATA) (CUSTOM) => constant_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => constant_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * dcim.virtualchassis => dcim.virtualchassis *******************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-domain (DATA) => value_importer => domain (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-master (DATA) => relation_importer => master_id (OneToOneField)
-name (DATA) => value_importer => name (CharField)
-* dcim.virtualdevicecontext => dcim.virtualdevicecontext *******************************************
-    Disable reason: Nautobot content type: `dcim.virtualdevicecontext` not found
-* django_rq.queue => django_rq.queue ***************************************************************
-    Disable reason: Nautobot content type: `django_rq.queue` not found
-* extras.branch => extras.branch *******************************************************************
-    Disable reason: Nautobot content type: `extras.branch` not found
-* extras.cachedvalue => extras.cachedvalue *********************************************************
-    Disable reason: Nautobot content type: `extras.cachedvalue` not found
-* extras.configcontext => extras.configcontext *****************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.configrevision => extras.configrevision ***************************************************
-    Disable reason: Nautobot content type: `extras.configrevision` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+domain => value_importer => domain (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+master => relation_importer => master_id (OneToOneField)
+name => value_importer => name (CharField)
 * extras.customfield => extras.customfield *********************************************************
-choice_set (DATA) (CUSTOM) => choices_importer => Custom Target
-choices (CUSTOM) => choices_importer => Custom Target
-content_types (DATA) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-default (DATA) => json_importer => default (JSONField)
-description (DATA) => value_importer => description (CharField)
-filter_logic (DATA) => value_importer => filter_logic (CharField)
-group_name (DATA) => NO IMPORTER => NO TARGET
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-label (DATA) => value_importer => label (CharField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) (CUSTOM) => value_importer => key (SlugField)
-object_type (DATA) => NO IMPORTER => NO TARGET
-required (DATA) => value_importer => required (BooleanField)
-search_weight (DATA) => NO IMPORTER => NO TARGET
-type (DATA) => value_importer => type (CharField)
-ui_visibility (DATA) => NO IMPORTER => NO TARGET
-validation_maximum (DATA) => integer_importer => validation_maximum (BigIntegerField)
-validation_minimum (DATA) => integer_importer => validation_minimum (BigIntegerField)
-validation_regex (DATA) => value_importer => validation_regex (CharField)
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
-* extras.customfieldchoice => extras.customfieldchoice *********************************************
-custom_field (CUSTOM) => relation_importer => custom_field_id (ForeignKey)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-value (CUSTOM) => value_importer => value (CharField)
-* extras.customfieldchoiceset => extras.customfieldchoiceset ***************************************
-    Disable reason: Nautobot content type: `extras.customfieldchoiceset` not found
-* extras.customlink => extras.customlink ***********************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.exporttemplate => extras.exporttemplate ***************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.imageattachment => extras.imageattachment *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.jobresult => extras.jobresult *************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.journalentry => extras.note ***************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.objectchange => extras.objectchange *******************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-postchange_data (CUSTOM) => json_importer => object_data (JSONField)
-time (CUSTOM) => datetime_importer => time (DateTimeField)
-* extras.report => extras.report *******************************************************************
-    Disable reason: Nautobot content type: `extras.report` not found
-* extras.role => extras.role ***********************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* extras.savedfilter => extras.savedfilter *********************************************************
-    Disable reason: Nautobot content type: `extras.savedfilter` not found
-* extras.script => extras.script *******************************************************************
-    Disable reason: Nautobot content type: `extras.script` not found
-* extras.stagedchange => extras.stagedchange *******************************************************
-    Disable reason: Nautobot content type: `extras.stagedchange` not found
-* extras.status => extras.status *******************************************************************
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-id (CUSTOM) => uid_from_data => id (UUIDField)
-name (DATA) => value_importer => name (CharField)
+choice_set => choices_importer => Custom Target
+content_types => content_types_importer => content_types (ManyToManyField)
+created => datetime_importer => created (DateTimeField)
+default => json_importer => default (JSONField)
+description => value_importer => description (CharField)
+filter_logic => value_importer => filter_logic (CharField)
+group_name => NO IMPORTER => NO TARGET
+id => uid_from_data => id (UUIDField)
+label => value_importer => label (CharField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => key (SlugField)
+object_type => NO IMPORTER => NO TARGET
+required => value_importer => required (BooleanField)
+search_weight => NO IMPORTER => NO TARGET
+type => value_importer => type (CharField)
+ui_visibility => NO IMPORTER => NO TARGET
+validation_maximum => integer_importer => validation_maximum (BigIntegerField)
+validation_minimum => integer_importer => validation_minimum (BigIntegerField)
+validation_regex => value_importer => validation_regex (CharField)
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * extras.tag => extras.tag *************************************************************************
-color (DATA) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+color => value_importer => color (CharField)
+created => datetime_importer => created (DateTimeField)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * extras.taggeditem => extras.taggeditem ***********************************************************
-content_type (DATA) => tagged_object_importer => content_type_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-object_id (DATA) (CUSTOM) => tagged_object_importer => object_id (UUIDField)
-tag (DATA) => tagged_object_importer => tag_id (ForeignKey)
-* extras.webhook => extras.webhook *****************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
+content_type => tagged_object_importer => content_type_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+object_id => tagged_object_importer => object_id (UUIDField)
+tag => tagged_object_importer => tag_id (ForeignKey)
 * ipam.aggregate => ipam.prefix ********************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-date_added (DATA) => NO IMPORTER => NO TARGET
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-prefix (DATA) => value_importer => prefix (Property)
-rir (DATA) => relation_importer => rir_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.asn => ipam.asn *****************************************************************************
-    Disable reason: Nautobot content type: `ipam.asn` not found
-* ipam.fhrpgroup => dcim.interfaceredundancygroup **************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-status (CUSTOM) => status_importer => status_id (StatusField)
-* ipam.fhrpgroupassignment => ipam.fhrpgroupassignment *********************************************
-    Disable reason: Nautobot content type: `ipam.fhrpgroupassignment` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+date_added => NO IMPORTER => NO TARGET
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+prefix => value_importer => prefix (Property)
+rir => relation_importer => rir_id (ForeignKey)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.ipaddress => ipam.ipaddress *****************************************************************
-address (DATA) => value_importer => address (Property)
-assigned_object_id (DATA) => NO IMPORTER => NO TARGET
-assigned_object_type (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-dns_name (DATA) => value_importer => dns_name (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-nat_inside (DATA) => relation_importer => nat_inside_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
-* ipam.iprange => ipam.iprange *********************************************************************
-    Disable reason: Nautobot content type: `ipam.iprange` not found
-* ipam.l2vpn => ipam.l2vpn *************************************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpn` not found
-* ipam.l2vpntermination => ipam.l2vpntermination ***************************************************
-    Disable reason: Nautobot content type: `ipam.l2vpntermination` not found
+address => value_importer => address (Property)
+assigned_object_id => NO IMPORTER => NO TARGET
+assigned_object_type => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+dns_name => value_importer => dns_name (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+nat_inside => relation_importer => nat_inside_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.prefix => ipam.prefix ***********************************************************************
-_children (DATA) => NO IMPORTER => NO TARGET
-_depth (DATA) => NO IMPORTER => NO TARGET
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_pool (DATA) => NO IMPORTER => NO TARGET
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-mark_utilized (DATA) => NO IMPORTER => NO TARGET
-prefix (DATA) => value_importer => prefix (Property)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vlan (DATA) => relation_importer => vlan_id (ForeignKey)
-vrf (DATA) => NO IMPORTER => NO TARGET
+_children => NO IMPORTER => NO TARGET
+_depth => NO IMPORTER => NO TARGET
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_pool => NO IMPORTER => NO TARGET
+last_updated => Disabled with reason: Last updated field is updated with each write
+mark_utilized => NO IMPORTER => NO TARGET
+prefix => value_importer => prefix (Property)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vlan => relation_importer => vlan_id (ForeignKey)
+vrf => NO IMPORTER => NO TARGET
 * ipam.rir => ipam.rir *****************************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-is_private (DATA) => value_importer => is_private (BooleanField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+is_private => value_importer => is_private (BooleanField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * ipam.role => extras.role *************************************************************************
-color (CUSTOM) => value_importer => color (CharField)
-content_types (CUSTOM) => content_types_importer => content_types (ManyToManyField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
-weight (DATA) => integer_importer => weight (PositiveSmallIntegerField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
+weight => integer_importer => weight (PositiveSmallIntegerField)
 * ipam.routetarget => ipam.routetarget *************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* ipam.service => ipam.service *********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* ipam.servicetemplate => ipam.servicetemplate *****************************************************
-    Disable reason: Nautobot content type: `ipam.servicetemplate` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * ipam.vlan => ipam.vlan ***************************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => vlan_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vid (DATA) => integer_importer => vid (PositiveSmallIntegerField)
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => vlan_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+role => relation_importer => role_id (RoleField)
+site => location_importer => location_id (ForeignKey)
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vid => integer_importer => vid (PositiveSmallIntegerField)
 * ipam.vlangroup => ipam.vlangroup *****************************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-max_vid (DATA) => NO IMPORTER => NO TARGET
-min_vid (DATA) => NO IMPORTER => NO TARGET
-name (DATA) => value_importer => name (CharField)
-scope_id (DATA) => NO IMPORTER => NO TARGET
-scope_type (DATA) => NO IMPORTER => NO TARGET
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+max_vid => NO IMPORTER => NO TARGET
+min_vid => NO IMPORTER => NO TARGET
+name => value_importer => name (CharField)
+scope_id => NO IMPORTER => NO TARGET
+scope_type => NO IMPORTER => NO TARGET
+slug => NO IMPORTER => NO TARGET
 * ipam.vrf => ipam.vrf *****************************************************************************
-comments (DATA) => NO IMPORTER => NO TARGET
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enforce_unique (DATA) => NO IMPORTER => NO TARGET
-export_targets (DATA) => uuids_importer => export_targets (ManyToManyField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-import_targets (DATA) => uuids_importer => import_targets (ManyToManyField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-rd (DATA) => value_importer => rd (CharField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-* secrets.secret => secrets.secret *****************************************************************
-    Disable reason: Nautobot content type: `secrets.secret` not found
-* secrets.secretrole => secrets.secretrole *********************************************************
-    Disable reason: Nautobot content type: `secrets.secretrole` not found
-* secrets.sessionkey => secrets.sessionkey *********************************************************
-    Disable reason: Nautobot content type: `secrets.sessionkey` not found
-* secrets.userkey => secrets.userkey ***************************************************************
-    Disable reason: Nautobot content type: `secrets.userkey` not found
-* sessions.session => sessions.session *************************************************************
-    Disable reason: Nautobot has own sessions, sessions should never cross apps.
-* social_django.association => social_django.association *******************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.code => social_django.code *********************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.nonce => social_django.nonce *******************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.partial => social_django.partial ***************************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* social_django.usersocialauth => social_django.usersocialauth *************************************
-id (CUSTOM) => uid_from_data => id (BigAutoField)
-* taggit.tag => taggit.tag *************************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* taggit.taggeditem => taggit.taggeditem ***********************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* tenancy.contact => tenancy.contact ***************************************************************
-    Disable reason: Nautobot content type: `tenancy.contact` not found
-* tenancy.contactassignment => tenancy.contactassignment *******************************************
-    Disable reason: Nautobot content type: `tenancy.contactassignment` not found
-* tenancy.contactgroup => tenancy.contactgroup *****************************************************
-    Disable reason: Nautobot content type: `tenancy.contactgroup` not found
-* tenancy.contactrole => tenancy.contactrole *******************************************************
-    Disable reason: Nautobot content type: `tenancy.contactrole` not found
+comments => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enforce_unique => NO IMPORTER => NO TARGET
+export_targets => uuids_importer => export_targets (ManyToManyField)
+id => uid_from_data => id (UUIDField)
+import_targets => uuids_importer => import_targets (ManyToManyField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+rd => value_importer => rd (CharField)
+tenant => relation_importer => tenant_id (ForeignKey)
 * tenancy.tenant => tenancy.tenant *****************************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-group (DATA) (CUSTOM) => relation_importer => tenant_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+group => relation_importer => tenant_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * tenancy.tenantgroup => tenancy.tenantgroup *******************************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-level (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-lft (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-name (DATA) => value_importer => name (CharField)
-parent (DATA) => relation_importer => parent_id (TreeNodeForeignKey)
-rght (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-slug (DATA) => NO IMPORTER => NO TARGET
-tree_id (DATA) (CUSTOM) => Disabled with reason: Tree fields doesn't need to be imported
-* users.admingroup => users.admingroup *************************************************************
-id (CUSTOM) => uid_from_data => id (AutoField)
-* users.adminuser => users.adminuser ***************************************************************
-    Disable reason: Nautobot content type: `users.adminuser` not found
-* users.objectpermission => users.objectpermission *************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.token => users.token ***********************************************************************
-id (CUSTOM) => uid_from_data => id (UUIDField)
-* users.userconfig => users.userconfig *************************************************************
-    Disable reason: May not have a 1 to 1 translation to Nautobot.
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+level => Disabled with reason: Tree fields doesn't need to be imported
+lft => Disabled with reason: Tree fields doesn't need to be imported
+name => value_importer => name (CharField)
+parent => relation_importer => parent_id (TreeNodeForeignKey)
+rght => Disabled with reason: Tree fields doesn't need to be imported
+slug => NO IMPORTER => NO TARGET
+tree_id => Disabled with reason: Tree fields doesn't need to be imported
 * virtualization.cluster => virtualization.cluster *************************************************
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-group (DATA) (CUSTOM) => relation_importer => cluster_group_id (ForeignKey)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-location (CUSTOM) => location_importer => location_id (ForeignKey)
-name (DATA) => value_importer => name (CharField)
-region (CUSTOM) => location_importer => location_id (ForeignKey)
-site (DATA) => location_importer => location_id (ForeignKey)
-status (DATA) => NO IMPORTER => NO TARGET
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-type (DATA) (CUSTOM) => relation_importer => cluster_type_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+group => relation_importer => cluster_group_id (ForeignKey)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+site => location_importer => location_id (ForeignKey)
+status => NO IMPORTER => NO TARGET
+tenant => relation_importer => tenant_id (ForeignKey)
+type => relation_importer => cluster_type_id (ForeignKey)
 * virtualization.clustergroup => virtualization.clustergroup ***************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.clustertype => virtualization.clustertype *****************************************
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-name (DATA) => value_importer => name (CharField)
-slug (DATA) => NO IMPORTER => NO TARGET
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+name => value_importer => name (CharField)
+slug => NO IMPORTER => NO TARGET
 * virtualization.virtualmachine => virtualization.virtualmachine ***********************************
-_name (DATA) => NO IMPORTER => NO TARGET
-cluster (DATA) => relation_importer => cluster_id (ForeignKey)
-comments (DATA) => value_importer => comments (TextField)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => NO IMPORTER => NO TARGET
-device (DATA) => NO IMPORTER => NO TARGET
-disk (DATA) => integer_importer => disk (PositiveIntegerField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-local_context_data (DATA) => NO IMPORTER => NO TARGET
-memory (DATA) => integer_importer => memory (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-platform (DATA) => relation_importer => platform_id (ForeignKey)
-primary_ip4 (DATA) => relation_importer => primary_ip4_id (ForeignKey)
-primary_ip6 (DATA) => relation_importer => primary_ip6_id (ForeignKey)
-role (DATA) (CUSTOM) => relation_importer => role_id (RoleField)
-site (DATA) => NO IMPORTER => NO TARGET
-status (DATA) => status_importer => status_id (StatusField)
-tenant (DATA) => relation_importer => tenant_id (ForeignKey)
-vcpus (DATA) => integer_importer => vcpus (PositiveSmallIntegerField)
+_name => NO IMPORTER => NO TARGET
+cluster => relation_importer => cluster_id (ForeignKey)
+comments => value_importer => comments (TextField)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => NO IMPORTER => NO TARGET
+device => NO IMPORTER => NO TARGET
+disk => integer_importer => disk (PositiveIntegerField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+local_context_data => NO IMPORTER => NO TARGET
+memory => integer_importer => memory (PositiveIntegerField)
+name => value_importer => name (CharField)
+platform => relation_importer => platform_id (ForeignKey)
+primary_ip4 => relation_importer => primary_ip4_id (ForeignKey)
+primary_ip6 => relation_importer => primary_ip6_id (ForeignKey)
+role => relation_importer => role_id (RoleField)
+site => NO IMPORTER => NO TARGET
+status => status_importer => status_id (StatusField)
+tenant => relation_importer => tenant_id (ForeignKey)
+vcpus => integer_importer => vcpus (PositiveSmallIntegerField)
 * virtualization.vminterface => virtualization.vminterface *****************************************
-_name (DATA) => NO IMPORTER => NO TARGET
-bridge (DATA) => relation_importer => bridge_id (ForeignKey)
-created (DATA) => datetime_importer => created (DateTimeField)
-custom_field_data (DATA) => value_importer => custom_field_data (CustomFieldData)
-description (DATA) => value_importer => description (CharField)
-enabled (DATA) => value_importer => enabled (BooleanField)
-id (DATA) (CUSTOM) => uid_from_data => id (UUIDField)
-last_updated (DATA) => Disabled with reason: Last updated field is updated with each write
-mac_address (DATA) => value_importer => mac_address (CharField)
-mode (DATA) => value_importer => mode (CharField)
-mtu (DATA) => integer_importer => mtu (PositiveIntegerField)
-name (DATA) => value_importer => name (CharField)
-parent (DATA) (CUSTOM) => relation_importer => parent_interface_id (ForeignKey)
-status (CUSTOM) => status_importer => status_id (StatusField)
-tagged_vlans (DATA) => uuids_importer => tagged_vlans (ManyToManyField)
-untagged_vlan (DATA) => relation_importer => untagged_vlan_id (ForeignKey)
-virtual_machine (DATA) => relation_importer => virtual_machine_id (ForeignKey)
-vrf (DATA) => relation_importer => vrf_id (ForeignKey)
-* wireless.wirelesslan => wireless.wirelesslan *****************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslan` not found
-* wireless.wirelesslangroup => wireless.wirelesslangroup *******************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslangroup` not found
-* wireless.wirelesslink => wireless.wirelesslink ***************************************************
-    Disable reason: Nautobot content type: `wireless.wirelesslink` not found
+_name => NO IMPORTER => NO TARGET
+bridge => relation_importer => bridge_id (ForeignKey)
+created => datetime_importer => created (DateTimeField)
+custom_field_data => value_importer => custom_field_data (CustomFieldData)
+description => value_importer => description (CharField)
+enabled => value_importer => enabled (BooleanField)
+id => uid_from_data => id (UUIDField)
+last_updated => Disabled with reason: Last updated field is updated with each write
+mac_address => value_importer => mac_address (CharField)
+mode => value_importer => mode (CharField)
+mtu => integer_importer => mtu (PositiveIntegerField)
+name => value_importer => name (CharField)
+parent => relation_importer => parent_interface_id (ForeignKey)
+tagged_vlans => uuids_importer => tagged_vlans (ManyToManyField)
+untagged_vlan => relation_importer => untagged_vlan_id (ForeignKey)
+virtual_machine => relation_importer => virtual_machine_id (ForeignKey)
+vrf => relation_importer => vrf_id (ForeignKey)
 = End of Import Summary. ===========================================================================


### PR DESCRIPTION
# Closes: NaN

## What's Changed

- Improved field sources handling and fixed flapping.
- Fixed the order of importer modules initialization.
- Cleaned-up unnecessary definitions.
- Updated text summary to print only mappings originating from input data.
